### PR TITLE
Add dashboard analytics API endpoints

### DIFF
--- a/dist/controllers/dashboardController.js
+++ b/dist/controllers/dashboardController.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const dashboardService_1 = __importDefault(require("../services/dashboardService"));
+const logger_1 = __importDefault(require("../utils/logger"));
+class DashboardController {
+    async getDashboard(request) {
+        const userId = request.userId;
+        logger_1.default.debug('Start get dashboard');
+        const dashboard = await dashboardService_1.default.getDashboard(userId);
+        logger_1.default.debug('Done get dashboard');
+        return dashboard;
+    }
+    async getInsights(request) {
+        const userId = request.userId;
+        logger_1.default.debug('Start get dashboard insights');
+        const insights = await dashboardService_1.default.getInsights(userId);
+        logger_1.default.debug('Done get dashboard insights');
+        return insights;
+    }
+}
+exports.default = new DashboardController();

--- a/dist/repositories/dashboardRepository.js
+++ b/dist/repositories/dashboardRepository.js
@@ -1,0 +1,102 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const client_1 = __importDefault(require("../prisma/client"));
+const client_2 = require("@prisma/client");
+const categoryHierarchy_1 = require("../utils/categoryHierarchy");
+const categoryRepository_1 = __importDefault(require("./categoryRepository"));
+class DashboardRepository {
+    async getMonthSummary(userId, year, month) {
+        var _a, _b, _c, _d;
+        const startOfMonth = new Date(year, month - 1, 1);
+        const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999);
+        const groups = await client_1.default.transaction.groupBy({
+            by: ['type'],
+            _sum: { value: true },
+            where: {
+                userId,
+                status: client_2.TransactionStatus.APPROVED,
+                date: { gte: startOfMonth, lte: endOfMonth },
+            },
+        });
+        const incomeGroup = groups.find((g) => g.type === client_2.TransactionType.INCOME);
+        const expenseGroup = groups.find((g) => g.type === client_2.TransactionType.EXPENSE);
+        const totalIncome = (_b = (_a = incomeGroup === null || incomeGroup === void 0 ? void 0 : incomeGroup._sum) === null || _a === void 0 ? void 0 : _a.value) !== null && _b !== void 0 ? _b : 0;
+        const totalExpense = (_d = (_c = expenseGroup === null || expenseGroup === void 0 ? void 0 : expenseGroup._sum) === null || _c === void 0 ? void 0 : _c.value) !== null && _d !== void 0 ? _d : 0;
+        const monthStr = `${year}-${String(month).padStart(2, '0')}`;
+        return {
+            month: monthStr,
+            totalIncome,
+            totalExpense,
+            savings: totalIncome - totalExpense,
+        };
+    }
+    async getTopCategoriesForMonth(userId, year, month, limit = 7) {
+        var _a, _b, _c, _d;
+        const startOfMonth = new Date(year, month - 1, 1);
+        const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999);
+        const groups = await client_1.default.transaction.groupBy({
+            by: ['categoryId'],
+            _sum: { value: true },
+            where: {
+                userId,
+                status: client_2.TransactionStatus.APPROVED,
+                type: client_2.TransactionType.EXPENSE,
+                date: { gte: startOfMonth, lte: endOfMonth },
+            },
+            orderBy: { _sum: { value: 'desc' } },
+        });
+        // Build parent map and aggregate at parent level
+        const parentMap = await (0, categoryHierarchy_1.buildCategoryParentMap)();
+        const topLevelCategories = await categoryRepository_1.default.getTopLevelCategories();
+        const topLevelIds = new Set(topLevelCategories.map((c) => c.id));
+        const parentAggregation = new Map();
+        for (const group of groups) {
+            if (!group.categoryId)
+                continue;
+            const parentId = (_a = parentMap.get(group.categoryId)) !== null && _a !== void 0 ? _a : group.categoryId;
+            const current = (_b = parentAggregation.get(parentId)) !== null && _b !== void 0 ? _b : 0;
+            parentAggregation.set(parentId, current + ((_d = (_c = group._sum) === null || _c === void 0 ? void 0 : _c.value) !== null && _d !== void 0 ? _d : 0));
+        }
+        // Sort by amount desc and take top N
+        const sorted = Array.from(parentAggregation.entries())
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, limit);
+        const categoryIds = sorted.map(([id]) => id);
+        // Resolve category names
+        const categories = await client_1.default.category.findMany({
+            where: { id: { in: categoryIds } },
+        });
+        const categoryNameMap = new Map(categories.map((c) => [c.id, c.name]));
+        return sorted.map(([categoryId, amount]) => {
+            var _a;
+            return ({
+                categoryId,
+                categoryName: (_a = categoryNameMap.get(categoryId)) !== null && _a !== void 0 ? _a : 'Unknown',
+                amount,
+            });
+        });
+    }
+    async getRecentTransactions(userId, limit = 5) {
+        const transactions = await client_1.default.transaction.findMany({
+            where: { userId, status: client_2.TransactionStatus.APPROVED },
+            orderBy: { date: 'desc' },
+            take: limit,
+            include: { category: { select: { name: true } } },
+        });
+        return transactions.map((t) => {
+            var _a, _b, _c;
+            return ({
+                id: t.id,
+                description: (_a = t.description) !== null && _a !== void 0 ? _a : '',
+                value: t.value,
+                date: t.date.toISOString(),
+                type: t.type,
+                categoryName: (_c = (_b = t.category) === null || _b === void 0 ? void 0 : _b.name) !== null && _c !== void 0 ? _c : 'Uncategorized',
+            });
+        });
+    }
+}
+exports.default = new DashboardRepository();

--- a/dist/routers/dashboardRouter.js
+++ b/dist/routers/dashboardRouter.js
@@ -1,0 +1,14 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const dashboardController_1 = __importDefault(require("../controllers/dashboardController"));
+const handleRequest_1 = require("../utils/handleRequest");
+const authMiddleware_1 = require("../middlewares/authMiddleware");
+const router = express_1.default.Router();
+router.use(authMiddleware_1.authenticateRequest);
+router.get('/', (0, handleRequest_1.handleRequest)((req) => dashboardController_1.default.getDashboard(req), 200));
+router.get('/insights', (0, handleRequest_1.handleRequest)((req) => dashboardController_1.default.getInsights(req), 200));
+exports.default = router;

--- a/dist/routers/index.js
+++ b/dist/routers/index.js
@@ -15,6 +15,7 @@ const scheduledTransactionRouter_1 = __importDefault(require("./scheduledTransac
 const trendRouter_1 = __importDefault(require("./trendRouter"));
 const importRouter_1 = __importDefault(require("./importRouter"));
 const chatRouter_1 = __importDefault(require("./chatRouter"));
+const dashboardRouter_1 = __importDefault(require("./dashboardRouter"));
 const excelExtractionWebhookController_1 = require("../controllers/excelExtractionWebhookController");
 const router = express_1.default.Router();
 router.use('/api/auth', authRouter_1.default);
@@ -28,6 +29,7 @@ router.use('/api/scheduled-transactions', scheduledTransactionRouter_1.default);
 router.use('/api/trends', trendRouter_1.default);
 router.use('/api/imports', importRouter_1.default);
 router.use('/api/chat', chatRouter_1.default);
+router.use('/api/dashboard', dashboardRouter_1.default);
 router.get('/', (req, res) => {
     res.send('ok');
 });

--- a/dist/services/dashboardService.js
+++ b/dist/services/dashboardService.js
@@ -1,0 +1,131 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const aiServiceFactory_1 = __importDefault(require("./ai/aiServiceFactory"));
+const dashboardRepository_1 = __importDefault(require("../repositories/dashboardRepository"));
+const logger_1 = __importDefault(require("../utils/logger"));
+const redisProvider_1 = require("../common/redisProvider");
+class DashboardService {
+    constructor() {
+        this.aiService = aiServiceFactory_1.default.getAIService();
+    }
+    async getDashboard(userId) {
+        const now = new Date();
+        const currentYear = now.getFullYear();
+        const currentMonth = now.getMonth() + 1;
+        const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+        const prevYear = prevDate.getFullYear();
+        const prevMonth = prevDate.getMonth() + 1;
+        const [currentMonthSummary, previousMonthSummary, topCategoriesCurrent, topCategoriesPrevious, recentTransactions,] = await Promise.all([
+            dashboardRepository_1.default.getMonthSummary(userId, currentYear, currentMonth),
+            dashboardRepository_1.default.getMonthSummary(userId, prevYear, prevMonth),
+            dashboardRepository_1.default.getTopCategoriesForMonth(userId, currentYear, currentMonth, 7),
+            dashboardRepository_1.default.getTopCategoriesForMonth(userId, prevYear, prevMonth, 7),
+            dashboardRepository_1.default.getRecentTransactions(userId, 5),
+        ]);
+        const monthComparison = this.buildMonthComparison(currentMonthSummary, previousMonthSummary);
+        const topCategories = this.mergeTopCategories(topCategoriesCurrent, topCategoriesPrevious, currentMonthSummary.totalExpense);
+        return { monthComparison, topCategories, recentTransactions };
+    }
+    async getInsights(userId) {
+        const now = new Date();
+        const cacheKey = `dashboard-insights:${userId}:${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+        try {
+            const cached = await (0, redisProvider_1.getValue)(cacheKey);
+            if (cached) {
+                return typeof cached === 'string' ? JSON.parse(cached) : cached;
+            }
+        }
+        catch (error) {
+            logger_1.default.error('Failed to read dashboard insights cache:', error);
+        }
+        const currentYear = now.getFullYear();
+        const currentMonth = now.getMonth() + 1;
+        const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+        const prevYear = prevDate.getFullYear();
+        const prevMonth = prevDate.getMonth() + 1;
+        try {
+            const [currentMonthSummary, previousMonthSummary, topCategories] = await Promise.all([
+                dashboardRepository_1.default.getMonthSummary(userId, currentYear, currentMonth),
+                dashboardRepository_1.default.getMonthSummary(userId, prevYear, prevMonth),
+                dashboardRepository_1.default.getTopCategoriesForMonth(userId, currentYear, currentMonth, 7),
+            ]);
+            const result = await this.generateAiInsights(currentMonthSummary, topCategories, previousMonthSummary);
+            if (result) {
+                try {
+                    await (0, redisProvider_1.setValue)(cacheKey, JSON.stringify(result), 3600); // 1 hour TTL
+                }
+                catch (cacheError) {
+                    logger_1.default.error('Failed to cache dashboard insights:', cacheError);
+                }
+            }
+            return result;
+        }
+        catch (error) {
+            logger_1.default.error('Failed to generate dashboard insights:', error);
+            return null;
+        }
+    }
+    calculatePercentageChange(current, previous) {
+        const amount = current - previous;
+        const percentage = previous === 0 ? 0 : ((current - previous) / previous) * 100;
+        let trend = 'stable';
+        if (percentage > 5)
+            trend = 'up';
+        else if (percentage < -5)
+            trend = 'down';
+        return { amount, percentage, trend };
+    }
+    buildMonthComparison(current, previous) {
+        return {
+            currentMonth: current,
+            previousMonth: previous,
+            incomeChange: this.calculatePercentageChange(current.totalIncome, previous.totalIncome),
+            expenseChange: this.calculatePercentageChange(current.totalExpense, previous.totalExpense),
+            savingsChange: this.calculatePercentageChange(current.savings, previous.savings),
+        };
+    }
+    mergeTopCategories(current, previous, totalExpense) {
+        const previousMap = new Map(previous.map((c) => [c.categoryId, c.amount]));
+        return current.map((cat) => {
+            var _a;
+            const previousMonthAmount = (_a = previousMap.get(cat.categoryId)) !== null && _a !== void 0 ? _a : 0;
+            const percentage = totalExpense === 0 ? 0 : (cat.amount / totalExpense) * 100;
+            const change = this.calculatePercentageChange(cat.amount, previousMonthAmount);
+            return {
+                categoryId: cat.categoryId,
+                categoryName: cat.categoryName,
+                amount: cat.amount,
+                percentage,
+                previousMonthAmount,
+                change,
+            };
+        });
+    }
+    async generateAiInsights(currentMonth, topCategories, previousMonth) {
+        try {
+            const categoriesSummary = topCategories
+                .map((c) => `${c.categoryName}: ${c.amount.toFixed(2)}`)
+                .join(', ');
+            const prompt = `Analyze these monthly expenses and provide insights.
+Current month (${currentMonth.month}): Income ${currentMonth.totalIncome.toFixed(2)}, Expenses ${currentMonth.totalExpense.toFixed(2)}, Savings ${currentMonth.savings.toFixed(2)}.
+Previous month (${previousMonth.month}): Income ${previousMonth.totalIncome.toFixed(2)}, Expenses ${previousMonth.totalExpense.toFixed(2)}, Savings ${previousMonth.savings.toFixed(2)}.
+Top spending categories this month: ${categoriesSummary}.
+
+Respond ONLY with valid JSON in this exact format (no markdown, no code blocks):
+{"unusualSpending": ["insight 1", "insight 2"], "summary": "A brief overall summary"}`;
+            const response = await this.aiService.analyzeExpenses(prompt);
+            // Try to parse the JSON response
+            const cleaned = response.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+            const parsed = JSON.parse(cleaned);
+            return parsed;
+        }
+        catch (error) {
+            logger_1.default.error('Failed to parse AI insights response:', error);
+            return null;
+        }
+    }
+}
+exports.default = new DashboardService();

--- a/dist/services/trendService.js
+++ b/dist/services/trendService.js
@@ -8,6 +8,7 @@ const logger_1 = __importDefault(require("../utils/logger"));
 const transactionRepository_1 = __importDefault(require("../repositories/transactionRepository"));
 const categoryRepository_1 = __importDefault(require("../repositories/categoryRepository"));
 const client_1 = require("@prisma/client");
+const categoryHierarchy_1 = require("../utils/categoryHierarchy");
 class TrendService {
     async getSpendingTrends(request, userId) {
         try {
@@ -61,7 +62,7 @@ class TrendService {
                 this.fetchTransactionsForPeriod(startDate, endDate, userId, request.transactionType),
                 this.fetchPreviousPeriodData(startDate, endDate, userId, request.transactionType),
                 categoryRepository_1.default.getTopLevelCategories(),
-                this.buildCategoryParentMap(),
+                (0, categoryHierarchy_1.buildCategoryParentMap)(),
             ]);
             // Initialize category trends with top-level categories
             const categoryTrends = new Map();
@@ -198,41 +199,6 @@ class TrendService {
             amount: data.amount,
             count: data.count,
         }));
-    }
-    async buildCategoryParentMap() {
-        const allCategories = await categoryRepository_1.default.getAllCategories();
-        const parentMap = new Map();
-        // First pass: Create a map of category ID to its parent ID
-        const categoryToParentMap = new Map();
-        for (const category of allCategories) {
-            if ('parentId' in category && category.parentId !== null) {
-                categoryToParentMap.set(category.id, category.parentId);
-            }
-        }
-        // Second pass: For each category, traverse up to find top-level parent
-        for (const category of allCategories) {
-            let currentId = category.id;
-            let parentId = categoryToParentMap.get(currentId);
-            // If we've already processed this category, skip it
-            if (parentMap.has(currentId))
-                continue;
-            // Keep going up the chain until we find a category with no parent
-            while (parentId) {
-                const nextParentId = categoryToParentMap.get(parentId);
-                if (!nextParentId) {
-                    // We found the top-level parent
-                    parentMap.set(currentId, parentId);
-                    break;
-                }
-                currentId = parentId;
-                parentId = nextParentId;
-            }
-            // If we didn't find a parent, this category is itself a top-level category
-            if (!parentMap.has(category.id)) {
-                parentMap.set(category.id, category.id);
-            }
-        }
-        return parentMap;
     }
 }
 exports.default = new TrendService();

--- a/dist/types/dashboard.js
+++ b/dist/types/dashboard.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/utils/categoryHierarchy.js
+++ b/dist/utils/categoryHierarchy.js
@@ -1,0 +1,42 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildCategoryParentMap = buildCategoryParentMap;
+const categoryRepository_1 = __importDefault(require("../repositories/categoryRepository"));
+async function buildCategoryParentMap() {
+    const allCategories = await categoryRepository_1.default.getAllCategories();
+    const parentMap = new Map();
+    // First pass: Create a map of category ID to its parent ID
+    const categoryToParentMap = new Map();
+    for (const category of allCategories) {
+        if ('parentId' in category && category.parentId !== null) {
+            categoryToParentMap.set(category.id, category.parentId);
+        }
+    }
+    // Second pass: For each category, traverse up to find top-level parent
+    for (const category of allCategories) {
+        let currentId = category.id;
+        let parentId = categoryToParentMap.get(currentId);
+        // If we've already processed this category, skip it
+        if (parentMap.has(currentId))
+            continue;
+        // Keep going up the chain until we find a category with no parent
+        while (parentId) {
+            const nextParentId = categoryToParentMap.get(parentId);
+            if (!nextParentId) {
+                // We found the top-level parent
+                parentMap.set(currentId, parentId);
+                break;
+            }
+            currentId = parentId;
+            parentId = nextParentId;
+        }
+        // If we didn't find a parent, this category is itself a top-level category
+        if (!parentMap.has(category.id)) {
+            parentMap.set(category.id, category.id);
+        }
+    }
+    return parentMap;
+}

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -1,0 +1,23 @@
+import { Request } from 'express';
+import dashboardService from '../services/dashboardService';
+import logger from '../utils/logger';
+
+class DashboardController {
+  async getDashboard(request: Request) {
+    const userId = request.userId as string;
+    logger.debug('Start get dashboard');
+    const dashboard = await dashboardService.getDashboard(userId);
+    logger.debug('Done get dashboard');
+    return dashboard;
+  }
+
+  async getInsights(request: Request) {
+    const userId = request.userId as string;
+    logger.debug('Start get dashboard insights');
+    const insights = await dashboardService.getInsights(userId);
+    logger.debug('Done get dashboard insights');
+    return insights;
+  }
+}
+
+export default new DashboardController();

--- a/src/repositories/dashboardRepository.ts
+++ b/src/repositories/dashboardRepository.ts
@@ -1,0 +1,118 @@
+import prisma from '../prisma/client';
+import { TransactionStatus, TransactionType } from '@prisma/client';
+import { MonthSummary, RecentTransaction } from '../types/dashboard';
+import { buildCategoryParentMap } from '../utils/categoryHierarchy';
+import categoryRepository from './categoryRepository';
+
+class DashboardRepository {
+  public async getMonthSummary(
+    userId: string,
+    year: number,
+    month: number,
+  ): Promise<MonthSummary> {
+    const startOfMonth = new Date(year, month - 1, 1);
+    const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999);
+
+    const groups = await prisma.transaction.groupBy({
+      by: ['type'],
+      _sum: { value: true },
+      where: {
+        userId,
+        status: TransactionStatus.APPROVED,
+        date: { gte: startOfMonth, lte: endOfMonth },
+      },
+    });
+
+    const incomeGroup = groups.find((g) => g.type === TransactionType.INCOME);
+    const expenseGroup = groups.find((g) => g.type === TransactionType.EXPENSE);
+
+    const totalIncome = incomeGroup?._sum?.value ?? 0;
+    const totalExpense = expenseGroup?._sum?.value ?? 0;
+
+    const monthStr = `${year}-${String(month).padStart(2, '0')}`;
+
+    return {
+      month: monthStr,
+      totalIncome,
+      totalExpense,
+      savings: totalIncome - totalExpense,
+    };
+  }
+
+  public async getTopCategoriesForMonth(
+    userId: string,
+    year: number,
+    month: number,
+    limit: number = 7,
+  ): Promise<{ categoryId: string; categoryName: string; amount: number }[]> {
+    const startOfMonth = new Date(year, month - 1, 1);
+    const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999);
+
+    const groups = await prisma.transaction.groupBy({
+      by: ['categoryId'],
+      _sum: { value: true },
+      where: {
+        userId,
+        status: TransactionStatus.APPROVED,
+        type: TransactionType.EXPENSE,
+        date: { gte: startOfMonth, lte: endOfMonth },
+      },
+      orderBy: { _sum: { value: 'desc' } },
+    });
+
+    // Build parent map and aggregate at parent level
+    const parentMap = await buildCategoryParentMap();
+    const topLevelCategories = await categoryRepository.getTopLevelCategories();
+    const topLevelIds = new Set(topLevelCategories.map((c) => c.id));
+
+    const parentAggregation = new Map<string, number>();
+    for (const group of groups) {
+      if (!group.categoryId) continue;
+      const parentId = parentMap.get(group.categoryId) ?? group.categoryId;
+      const current = parentAggregation.get(parentId) ?? 0;
+      parentAggregation.set(parentId, current + (group._sum?.value ?? 0));
+    }
+
+    // Sort by amount desc and take top N
+    const sorted = Array.from(parentAggregation.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit);
+
+    const categoryIds = sorted.map(([id]) => id);
+
+    // Resolve category names
+    const categories = await prisma.category.findMany({
+      where: { id: { in: categoryIds } },
+    });
+    const categoryNameMap = new Map(categories.map((c) => [c.id, c.name]));
+
+    return sorted.map(([categoryId, amount]) => ({
+      categoryId,
+      categoryName: categoryNameMap.get(categoryId) ?? 'Unknown',
+      amount,
+    }));
+  }
+
+  public async getRecentTransactions(
+    userId: string,
+    limit: number = 5,
+  ): Promise<RecentTransaction[]> {
+    const transactions = await prisma.transaction.findMany({
+      where: { userId, status: TransactionStatus.APPROVED },
+      orderBy: { date: 'desc' },
+      take: limit,
+      include: { category: { select: { name: true } } },
+    });
+
+    return transactions.map((t) => ({
+      id: t.id,
+      description: t.description ?? '',
+      value: t.value,
+      date: t.date.toISOString(),
+      type: t.type as 'INCOME' | 'EXPENSE',
+      categoryName: t.category?.name ?? 'Uncategorized',
+    }));
+  }
+}
+
+export default new DashboardRepository();

--- a/src/routers/dashboardRouter.ts
+++ b/src/routers/dashboardRouter.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import dashboardController from '../controllers/dashboardController';
+import { handleRequest } from '../utils/handleRequest';
+import { authenticateRequest } from '../middlewares/authMiddleware';
+
+const router = express.Router();
+router.use(authenticateRequest);
+
+router.get(
+  '/',
+  handleRequest((req) => dashboardController.getDashboard(req), 200),
+);
+
+router.get(
+  '/insights',
+  handleRequest((req) => dashboardController.getInsights(req), 200),
+);
+
+export default router;

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -10,6 +10,7 @@ import scheduledTransactionRouter from './scheduledTransactionRouter';
 import trendRouter from './trendRouter';
 import importRouter from './importRouter';
 import chatRouter from './chatRouter';
+import dashboardRouter from './dashboardRouter';
 import { excelExtractionWebhookController } from '../controllers/excelExtractionWebhookController';
 
 const router = express.Router();
@@ -25,6 +26,7 @@ router.use('/api/scheduled-transactions', scheduledTransactionRouter);
 router.use('/api/trends', trendRouter);
 router.use('/api/imports', importRouter);
 router.use('/api/chat', chatRouter);
+router.use('/api/dashboard', dashboardRouter);
 
 router.get('/', (req, res) => {
   res.send('ok');

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,214 @@
+import AIServiceFactory from './ai/aiServiceFactory';
+import dashboardRepository from '../repositories/dashboardRepository';
+import {
+  DashboardResponse,
+  DashboardInsightsResponse,
+  MonthComparison,
+  MonthSummary,
+  PercentageChange,
+  TopCategory,
+} from '../types/dashboard';
+import logger from '../utils/logger';
+import { getValue, setValue } from '../common/redisProvider';
+
+class DashboardService {
+  private aiService = AIServiceFactory.getAIService();
+
+  public async getDashboard(userId: string): Promise<DashboardResponse> {
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+    const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const prevYear = prevDate.getFullYear();
+    const prevMonth = prevDate.getMonth() + 1;
+
+    const [
+      currentMonthSummary,
+      previousMonthSummary,
+      topCategoriesCurrent,
+      topCategoriesPrevious,
+      recentTransactions,
+    ] = await Promise.all([
+      dashboardRepository.getMonthSummary(userId, currentYear, currentMonth),
+      dashboardRepository.getMonthSummary(userId, prevYear, prevMonth),
+      dashboardRepository.getTopCategoriesForMonth(
+        userId,
+        currentYear,
+        currentMonth,
+        7,
+      ),
+      dashboardRepository.getTopCategoriesForMonth(
+        userId,
+        prevYear,
+        prevMonth,
+        7,
+      ),
+      dashboardRepository.getRecentTransactions(userId, 5),
+    ]);
+
+    const monthComparison = this.buildMonthComparison(
+      currentMonthSummary,
+      previousMonthSummary,
+    );
+    const topCategories = this.mergeTopCategories(
+      topCategoriesCurrent,
+      topCategoriesPrevious,
+      currentMonthSummary.totalExpense,
+    );
+
+    return { monthComparison, topCategories, recentTransactions };
+  }
+
+  public async getInsights(
+    userId: string,
+  ): Promise<DashboardInsightsResponse | null> {
+    const now = new Date();
+    const cacheKey = `dashboard-insights:${userId}:${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+    try {
+      const cached = await getValue(cacheKey);
+      if (cached) {
+        return typeof cached === 'string' ? JSON.parse(cached) : cached;
+      }
+    } catch (error) {
+      logger.error('Failed to read dashboard insights cache:', error);
+    }
+
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+    const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const prevYear = prevDate.getFullYear();
+    const prevMonth = prevDate.getMonth() + 1;
+
+    try {
+      const [currentMonthSummary, previousMonthSummary, topCategories] =
+        await Promise.all([
+          dashboardRepository.getMonthSummary(
+            userId,
+            currentYear,
+            currentMonth,
+          ),
+          dashboardRepository.getMonthSummary(userId, prevYear, prevMonth),
+          dashboardRepository.getTopCategoriesForMonth(
+            userId,
+            currentYear,
+            currentMonth,
+            7,
+          ),
+        ]);
+
+      const result = await this.generateAiInsights(
+        currentMonthSummary,
+        topCategories,
+        previousMonthSummary,
+      );
+      if (result) {
+        try {
+          await setValue(cacheKey, JSON.stringify(result), 3600); // 1 hour TTL
+        } catch (cacheError) {
+          logger.error('Failed to cache dashboard insights:', cacheError);
+        }
+      }
+      return result;
+    } catch (error) {
+      logger.error('Failed to generate dashboard insights:', error);
+      return null;
+    }
+  }
+
+  private calculatePercentageChange(
+    current: number,
+    previous: number,
+  ): PercentageChange {
+    const amount = current - previous;
+    const percentage =
+      previous === 0 ? 0 : ((current - previous) / previous) * 100;
+    let trend: 'up' | 'down' | 'stable' = 'stable';
+    if (percentage > 5) trend = 'up';
+    else if (percentage < -5) trend = 'down';
+    return { amount, percentage, trend };
+  }
+
+  private buildMonthComparison(
+    current: MonthSummary,
+    previous: MonthSummary,
+  ): MonthComparison {
+    return {
+      currentMonth: current,
+      previousMonth: previous,
+      incomeChange: this.calculatePercentageChange(
+        current.totalIncome,
+        previous.totalIncome,
+      ),
+      expenseChange: this.calculatePercentageChange(
+        current.totalExpense,
+        previous.totalExpense,
+      ),
+      savingsChange: this.calculatePercentageChange(
+        current.savings,
+        previous.savings,
+      ),
+    };
+  }
+
+  private mergeTopCategories(
+    current: { categoryId: string; categoryName: string; amount: number }[],
+    previous: { categoryId: string; categoryName: string; amount: number }[],
+    totalExpense: number,
+  ): TopCategory[] {
+    const previousMap = new Map(
+      previous.map((c) => [c.categoryId, c.amount]),
+    );
+
+    return current.map((cat) => {
+      const previousMonthAmount = previousMap.get(cat.categoryId) ?? 0;
+      const percentage =
+        totalExpense === 0 ? 0 : (cat.amount / totalExpense) * 100;
+      const change = this.calculatePercentageChange(
+        cat.amount,
+        previousMonthAmount,
+      );
+
+      return {
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        amount: cat.amount,
+        percentage,
+        previousMonthAmount,
+        change,
+      };
+    });
+  }
+
+  private async generateAiInsights(
+    currentMonth: MonthSummary,
+    topCategories: { categoryId: string; categoryName: string; amount: number }[],
+    previousMonth: MonthSummary,
+  ): Promise<DashboardInsightsResponse | null> {
+    try {
+      const categoriesSummary = topCategories
+        .map((c) => `${c.categoryName}: ${c.amount.toFixed(2)}`)
+        .join(', ');
+
+      const prompt = `Analyze these monthly expenses and provide insights.
+Current month (${currentMonth.month}): Income ${currentMonth.totalIncome.toFixed(2)}, Expenses ${currentMonth.totalExpense.toFixed(2)}, Savings ${currentMonth.savings.toFixed(2)}.
+Previous month (${previousMonth.month}): Income ${previousMonth.totalIncome.toFixed(2)}, Expenses ${previousMonth.totalExpense.toFixed(2)}, Savings ${previousMonth.savings.toFixed(2)}.
+Top spending categories this month: ${categoriesSummary}.
+
+Respond ONLY with valid JSON in this exact format (no markdown, no code blocks):
+{"unusualSpending": ["insight 1", "insight 2"], "summary": "A brief overall summary"}`;
+
+      const response = await this.aiService.analyzeExpenses(prompt);
+
+      // Try to parse the JSON response
+      const cleaned = response.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+      const parsed = JSON.parse(cleaned) as DashboardInsightsResponse;
+      return parsed;
+    } catch (error) {
+      logger.error('Failed to parse AI insights response:', error);
+      return null;
+    }
+  }
+}
+
+export default new DashboardService();

--- a/src/services/trendService.ts
+++ b/src/services/trendService.ts
@@ -10,6 +10,7 @@ import logger from '../utils/logger';
 import transactionRepository from '../repositories/transactionRepository';
 import categoryRepository from '../repositories/categoryRepository';
 import { TransactionStatus, TransactionType } from '@prisma/client';
+import { buildCategoryParentMap } from '../utils/categoryHierarchy';
 
 interface CategoryTrendData {
   points: CategoryTrendPoint[];
@@ -109,7 +110,7 @@ class TrendService {
           request.transactionType,
         ),
         categoryRepository.getTopLevelCategories(),
-        this.buildCategoryParentMap(),
+        buildCategoryParentMap(),
       ]);
 
       // Initialize category trends with top-level categories
@@ -344,49 +345,6 @@ class TrendService {
     }));
   }
 
-  private async buildCategoryParentMap(): Promise<Map<string, string>> {
-    const allCategories = await categoryRepository.getAllCategories();
-    const parentMap = new Map<string, string>();
-
-    // First pass: Create a map of category ID to its parent ID
-    const categoryToParentMap = new Map<string, string | null>();
-    for (const category of allCategories) {
-      if ('parentId' in category && (category as any).parentId !== null) {
-        categoryToParentMap.set(
-          category.id,
-          (category as any).parentId as string,
-        );
-      }
-    }
-
-    // Second pass: For each category, traverse up to find top-level parent
-    for (const category of allCategories) {
-      let currentId = category.id;
-      let parentId = categoryToParentMap.get(currentId);
-
-      // If we've already processed this category, skip it
-      if (parentMap.has(currentId)) continue;
-
-      // Keep going up the chain until we find a category with no parent
-      while (parentId) {
-        const nextParentId = categoryToParentMap.get(parentId);
-        if (!nextParentId) {
-          // We found the top-level parent
-          parentMap.set(currentId, parentId);
-          break;
-        }
-        currentId = parentId;
-        parentId = nextParentId;
-      }
-
-      // If we didn't find a parent, this category is itself a top-level category
-      if (!parentMap.has(category.id)) {
-        parentMap.set(category.id, category.id);
-      }
-    }
-
-    return parentMap;
-  }
 }
 
 export default new TrendService();

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,49 @@
+export interface DashboardResponse {
+  monthComparison: MonthComparison;
+  topCategories: TopCategory[];
+  recentTransactions: RecentTransaction[];
+}
+
+export interface DashboardInsightsResponse {
+  unusualSpending: string[];
+  summary: string;
+}
+
+export interface MonthComparison {
+  currentMonth: MonthSummary;
+  previousMonth: MonthSummary;
+  incomeChange: PercentageChange;
+  expenseChange: PercentageChange;
+  savingsChange: PercentageChange;
+}
+
+export interface MonthSummary {
+  month: string; // "YYYY-MM"
+  totalIncome: number;
+  totalExpense: number;
+  savings: number; // income - expense
+}
+
+export interface PercentageChange {
+  amount: number;
+  percentage: number;
+  trend: 'up' | 'down' | 'stable';
+}
+
+export interface TopCategory {
+  categoryId: string;
+  categoryName: string;
+  amount: number;
+  percentage: number;
+  previousMonthAmount: number;
+  change: PercentageChange;
+}
+
+export interface RecentTransaction {
+  id: string;
+  description: string;
+  value: number;
+  date: string;
+  type: 'INCOME' | 'EXPENSE';
+  categoryName: string;
+}

--- a/src/utils/categoryHierarchy.ts
+++ b/src/utils/categoryHierarchy.ts
@@ -1,0 +1,45 @@
+import categoryRepository from '../repositories/categoryRepository';
+
+export async function buildCategoryParentMap(): Promise<Map<string, string>> {
+  const allCategories = await categoryRepository.getAllCategories();
+  const parentMap = new Map<string, string>();
+
+  // First pass: Create a map of category ID to its parent ID
+  const categoryToParentMap = new Map<string, string | null>();
+  for (const category of allCategories) {
+    if ('parentId' in category && (category as any).parentId !== null) {
+      categoryToParentMap.set(
+        category.id,
+        (category as any).parentId as string,
+      );
+    }
+  }
+
+  // Second pass: For each category, traverse up to find top-level parent
+  for (const category of allCategories) {
+    let currentId = category.id;
+    let parentId = categoryToParentMap.get(currentId);
+
+    // If we've already processed this category, skip it
+    if (parentMap.has(currentId)) continue;
+
+    // Keep going up the chain until we find a category with no parent
+    while (parentId) {
+      const nextParentId = categoryToParentMap.get(parentId);
+      if (!nextParentId) {
+        // We found the top-level parent
+        parentMap.set(currentId, parentId);
+        break;
+      }
+      currentId = parentId;
+      parentId = nextParentId;
+    }
+
+    // If we didn't find a parent, this category is itself a top-level category
+    if (!parentMap.has(category.id)) {
+      parentMap.set(category.id, category.id);
+    }
+  }
+
+  return parentMap;
+}


### PR DESCRIPTION
## Summary
- New `/api/dashboard` endpoint with month-over-month comparison, top categories (parent-level aggregation via Prisma groupBy), and recent transactions
- New `/api/dashboard/insights` endpoint for AI-generated spending analysis with Redis caching (1h TTL)
- Extracted `buildCategoryParentMap` from trendService into shared `categoryHierarchy.ts` utility

## New files
- `src/utils/categoryHierarchy.ts` — shared category hierarchy utility
- `src/types/dashboard.ts` — response types
- `src/repositories/dashboardRepository.ts` — Prisma groupBy aggregation queries
- `src/services/dashboardService.ts` — business logic + AI insights
- `src/controllers/dashboardController.ts` — request handlers
- `src/routers/dashboardRouter.ts` — route definitions

## Modified files
- `src/services/trendService.ts` — uses shared categoryHierarchy utility
- `src/routers/index.ts` — registers `/api/dashboard`

## Test plan
- [ ] Verify `GET /api/dashboard` returns monthComparison, topCategories, recentTransactions
- [ ] Verify `GET /api/dashboard/insights` returns AI insights (or null on failure)
- [ ] Verify insights are cached in Redis with 1h TTL
- [ ] Verify trends endpoint still works after trendService refactor
- [ ] Verify empty state handling (new user with no transactions)

Generated with [Claude Code](https://claude.com/claude-code)