### PR TITLE
Improve transaction categorization accuracy

### DIFF
--- a/dist/controllers/transactionController.js
+++ b/dist/controllers/transactionController.js
@@ -9,9 +9,9 @@ class TransactionController {
     async createTransaction(createTransactionRequest, userId) {
         try {
             logger_1.default.debug('Start create transaction', createTransactionRequest);
-            const transactionId = await transactionService_1.default.createTransaction(Object.assign(Object.assign({}, createTransactionRequest), { date: createTransactionRequest.date || new Date(), categoryId: createTransactionRequest.categoryId || null, userId }));
-            logger_1.default.debug('Done create transaction', createTransactionRequest, transactionId);
-            return transactionId;
+            const result = await transactionService_1.default.createTransaction(Object.assign(Object.assign({}, createTransactionRequest), { date: createTransactionRequest.date || new Date(), categoryId: createTransactionRequest.categoryId || null, userId }));
+            logger_1.default.debug('Done create transaction', createTransactionRequest, result.id);
+            return result;
         }
         catch (error) {
             logger_1.default.error(`Failed to create transaction, ${JSON.stringify(createTransactionRequest)}, ${error.message}`);

--- a/dist/repositories/userCategoryMappingRepository.js
+++ b/dist/repositories/userCategoryMappingRepository.js
@@ -1,0 +1,33 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const client_1 = __importDefault(require("../prisma/client"));
+class UserCategoryMappingRepository {
+    async findByUserAndDescription(userId, descriptionPattern) {
+        return client_1.default.userCategoryMapping.findUnique({
+            where: {
+                userId_descriptionPattern: { userId, descriptionPattern },
+            },
+            select: { categoryId: true },
+        });
+    }
+    async upsert(userId, descriptionPattern, categoryId) {
+        await client_1.default.userCategoryMapping.upsert({
+            where: {
+                userId_descriptionPattern: { userId, descriptionPattern },
+            },
+            update: {
+                categoryId,
+                hitCount: { increment: 1 },
+            },
+            create: {
+                userId,
+                descriptionPattern,
+                categoryId,
+            },
+        });
+    }
+}
+exports.default = new UserCategoryMappingRepository();

--- a/dist/services/ai/chatGPTService.js
+++ b/dist/services/ai/chatGPTService.js
@@ -55,9 +55,14 @@ class ChatGPTService {
             return 'I encountered an issue analyzing your expenses.';
         }
     }
-    async suggestCategory(expenseDescription, categoryOptions) {
-        var _a;
+    async suggestCategory(expenseDescription, categoryOptions, categorizerHint) {
+        var _a, _b;
         try {
+            let userContent = `Which category does this expense belong to?\n\n"${expenseDescription}"\n\nAvailable categories:\n${categoryOptions.map((c) => `- ${c.name}`).join('\n')}`;
+            if (categorizerHint) {
+                userContent += `\n\nA machine learning model suggested "${categorizerHint.hint}" with ${Math.round(categorizerHint.confidence * 100)}% confidence. Consider this suggestion but use your own judgment.`;
+            }
+            userContent += '\n\nReturn only the category name, nothing else.';
             const response = await this.openai.chat.completions.create({
                 model: 'gpt-4-turbo',
                 messages: [
@@ -67,12 +72,12 @@ class ChatGPTService {
                     },
                     {
                         role: 'user',
-                        content: `Which category does this expense belong to?\n\n"${expenseDescription}", here are the available options:\n${categoryOptions.map((category) => `- ${category.name}\n, return only the category name`)}`,
+                        content: userContent,
                     },
                 ],
                 max_tokens: 50,
             });
-            const aiSuggestedCategory = (_a = response.choices[0].message) === null || _a === void 0 ? void 0 : _a.content;
+            const aiSuggestedCategory = (_b = (_a = response.choices[0].message) === null || _a === void 0 ? void 0 : _a.content) === null || _b === void 0 ? void 0 : _b.trim();
             const suggestedCategory = categoryOptions.find((category) => category.name === aiSuggestedCategory);
             return (suggestedCategory === null || suggestedCategory === void 0 ? void 0 : suggestedCategory.id) || 'No category found.';
         }

--- a/dist/services/ai/geminiService.js
+++ b/dist/services/ai/geminiService.js
@@ -63,20 +63,21 @@ class GeminiService {
             return 'I encountered an issue analyzing your expenses.';
         }
     }
-    async suggestCategory(expenseDescription, categoryOptions) {
+    async suggestCategory(expenseDescription, categoryOptions, categorizerHint) {
         var _a, _b, _c, _d, _e, _f, _g;
         try {
             logger_1.default.debug(`Start suggesting category for expense: ${expenseDescription}`);
             const model = this.gemini.getGenerativeModel({ model: this.modelName });
+            let promptText = `Which category does this expense belong to?\n\n"${expenseDescription}"\n\nAvailable categories:\n${categoryOptions.map((c) => `- ${c.name}`).join('\n')}`;
+            if (categorizerHint) {
+                promptText += `\n\nA machine learning model suggested "${categorizerHint.hint}" with ${Math.round(categorizerHint.confidence * 100)}% confidence. Consider this suggestion but use your own judgment.`;
+            }
+            promptText += '\n\nReturn only the category name, nothing else.';
             const response = await model.generateContent({
                 contents: [
                     {
                         role: 'user',
-                        parts: [
-                            {
-                                text: `Which category does this expense belong to?\n\n"${expenseDescription}", here are the available options:\n${categoryOptions.map((category) => `- ${category.name}\n, return only the category name`)}`,
-                            },
-                        ],
+                        parts: [{ text: promptText }],
                     },
                 ],
             });

--- a/dist/services/transactionManager.js
+++ b/dist/services/transactionManager.js
@@ -125,7 +125,7 @@ class TransactionManager {
         const date = ['now', 'today'].includes(sanitizedText)
             ? new Date()
             : new Date(sanitizedText);
-        const createdTransaction = await transactionService_1.default.createTransaction({
+        const createdResult = await transactionService_1.default.createTransaction({
             type: inProcessTransaction.type,
             value: inProcessTransaction.value,
             description: inProcessTransaction.description,
@@ -133,7 +133,7 @@ class TransactionManager {
             date,
             userId,
         });
-        const transaction = await transactionService_1.default.getTransactionItem(createdTransaction, userId);
+        const transaction = await transactionService_1.default.getTransactionItem(createdResult.id, userId);
         if (!transaction) {
             return {
                 message: 'Transaction created, but failed to retrieve details.',

--- a/dist/services/transactionService.js
+++ b/dist/services/transactionService.js
@@ -12,6 +12,7 @@ const axios_1 = __importDefault(require("axios"));
 const logger_1 = __importDefault(require("../utils/logger"));
 const transactionNotifierFactory_1 = __importDefault(require("./transactionNotification/transactionNotifierFactory"));
 const userSettingsService_1 = __importDefault(require("../services/userSettingsService"));
+const userCategoryMappingRepository_1 = __importDefault(require("../repositories/userCategoryMappingRepository"));
 const transactionAttachmentFileUtils_1 = require("./transactionAttachmentFileUtils");
 class TransactionService {
     constructor() {
@@ -19,6 +20,7 @@ class TransactionService {
         this.transactionNotifier = transactionNotifierFactory_1.default.getNotifier();
     }
     async createTransaction(data) {
+        const userProvidedCategory = !!data.categoryId;
         const createTransaction = await this.updateCategory(data);
         await createTransactionValidator_1.default.validate(createTransaction);
         const CreateTransactionDbModel = {
@@ -32,7 +34,15 @@ class TransactionService {
         };
         const transactionId = await transactionRepository_1.default.createTransaction(CreateTransactionDbModel);
         await this.notifyTransactionCreatedSafe(transactionId, createTransaction.userId);
-        return transactionId;
+        const result = { id: transactionId };
+        if (!userProvidedCategory && createTransaction.categoryId) {
+            const categories = await categoryRepository_1.default.getAllCategories();
+            const cat = categories.find((c) => c.id === createTransaction.categoryId);
+            if (cat) {
+                result.suggestedCategory = { id: cat.id, name: cat.name };
+            }
+        }
+        return result;
     }
     async getTransactions(filters) {
         return transactionRepository_1.default.getTransactions(Object.assign(Object.assign({}, filters), { status: filters.status || 'APPROVED', smartSearch: filters.smartSearch !== undefined ? filters.smartSearch : true }));
@@ -70,6 +80,21 @@ class TransactionService {
         return transactionRepository_1.default.getTransactionsSummary(Object.assign(Object.assign({}, filters), { status: filters.status || 'APPROVED' }));
     }
     async updateTransaction(id, data, userId) {
+        if (data.categoryId) {
+            try {
+                const existing = await transactionRepository_1.default.getTransactionItem(id, userId);
+                if (existing && existing.category.id !== data.categoryId) {
+                    const normalizedDescription = existing.description
+                        .toLowerCase()
+                        .trim();
+                    await userCategoryMappingRepository_1.default.upsert(userId, normalizedDescription, data.categoryId);
+                    logger_1.default.debug(`Saved category mapping: "${normalizedDescription}" -> ${data.categoryId}`);
+                }
+            }
+            catch (err) {
+                logger_1.default.warn(`Failed to save category mapping on update: ${err}`);
+            }
+        }
         await transactionRepository_1.default.updateTransaction(id, data, userId);
     }
     async deleteTransaction(id, userId) {
@@ -112,30 +137,53 @@ class TransactionService {
             return transaction;
         }
         const categories = await categoryRepository_1.default.getAllCategories();
-        const suggestedCategoryId = await this.getSuggestedCategory(transaction.description, categories);
+        const suggestedCategoryId = await this.getSuggestedCategory(transaction.description, transaction.userId, categories);
         return Object.assign(Object.assign({}, transaction), { categoryId: suggestedCategoryId });
     }
-    async getSuggestedCategory(description, categories) {
-        var _a;
-        let categoryFoundUsingCategorizer = false;
-        let category = null;
+    async getSuggestedCategory(description, userId, categories) {
+        // 1. Check user category mappings first (learned from corrections)
         try {
-            category = await this.categorizeExpense(description);
-            if (category && categories.find((c) => c.name === category)) {
-                categoryFoundUsingCategorizer = true;
+            const normalizedDescription = description.toLowerCase().trim();
+            const mapping = await userCategoryMappingRepository_1.default.findByUserAndDescription(userId, normalizedDescription);
+            if (mapping) {
+                const cat = categories.find((c) => c.id === mapping.categoryId);
+                if (cat) {
+                    logger_1.default.debug(`User mapping found for expense: ${description} -> ${cat.name}`);
+                    return cat.id;
+                }
             }
+        }
+        catch (err) {
+            logger_1.default.warn(`Failed to check user category mapping: ${err}`);
+        }
+        // 2. Try FastText categorizer with confidence routing
+        let categorizerResult = null;
+        try {
+            categorizerResult = await this.categorizeExpense(description);
         }
         catch (err) {
             logger_1.default.warn(`Failed to categorize expense: ${description}`);
         }
-        if (categoryFoundUsingCategorizer) {
-            logger_1.default.debug(`Categorizer found category for expense: ${description} - ${category}`);
-            return (_a = categories.find((c) => c.name === category)) === null || _a === void 0 ? void 0 : _a.id;
+        if (categorizerResult) {
+            const matchedCategory = categories.find((c) => c.name === categorizerResult.category);
+            if (matchedCategory && categorizerResult.confidence >= 0.7) {
+                logger_1.default.debug(`High confidence (${categorizerResult.confidence.toFixed(2)}) category: ${categorizerResult.category}`);
+                return matchedCategory.id;
+            }
+            if (matchedCategory && categorizerResult.confidence >= 0.4) {
+                logger_1.default.debug(`Medium confidence (${categorizerResult.confidence.toFixed(2)}), passing hint to LLM: ${categorizerResult.category}`);
+                return this.aiService.suggestCategory(description, categories, {
+                    hint: categorizerResult.category,
+                    confidence: categorizerResult.confidence,
+                });
+            }
         }
-        logger_1.default.warn(`No category found for expense using categorizer. Using AI service instead.`);
+        // 3. Low confidence or no result — LLM fallback without hint
+        logger_1.default.warn(`No reliable category from categorizer for: ${description}. Using AI service.`);
         return this.aiService.suggestCategory(description, categories);
     }
     async categorizeExpense(description) {
+        var _a;
         const expenseCategorizerBaseUrl = process.env.EXPENSE_CATEGORIZER_BASE_URL;
         const response = await axios_1.default.post(`${expenseCategorizerBaseUrl}/predict`, {
             description,
@@ -145,7 +193,10 @@ class TransactionService {
             logger_1.default.error('No category found for expense using categorizer.');
             return null;
         }
-        return response.data.category;
+        return {
+            category: response.data.category,
+            confidence: (_a = response.data.confidence) !== null && _a !== void 0 ? _a : 0,
+        };
     }
     async notifyTransactionCreatedSafe(transactionId, userId) {
         try {

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -15,7 +15,7 @@ class TransactionController {
   ) {
     try {
       logger.debug('Start create transaction', createTransactionRequest);
-      const transactionId = await transactionService.createTransaction({
+      const result = await transactionService.createTransaction({
         ...createTransactionRequest,
         date: createTransactionRequest.date || new Date(),
         categoryId: createTransactionRequest.categoryId || null,
@@ -24,9 +24,9 @@ class TransactionController {
       logger.debug(
         'Done create transaction',
         createTransactionRequest,
-        transactionId,
+        result.id,
       );
-      return transactionId;
+      return result;
     } catch (error: any) {
       logger.error(
         `Failed to create transaction, ${JSON.stringify(createTransactionRequest)}, ${error.message}`,

--- a/src/prisma/migrations/20260307124406_add_user_category_mapping/migration.sql
+++ b/src/prisma/migrations/20260307124406_add_user_category_mapping/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "UserCategoryMapping" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "descriptionPattern" TEXT NOT NULL,
+    "categoryId" UUID NOT NULL,
+    "hitCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserCategoryMapping_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UserCategoryMapping_userId_idx" ON "UserCategoryMapping"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserCategoryMapping_userId_descriptionPattern_key" ON "UserCategoryMapping"("userId", "descriptionPattern");
+
+-- AddForeignKey
+ALTER TABLE "UserCategoryMapping" ADD CONSTRAINT "UserCategoryMapping_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserCategoryMapping" ADD CONSTRAINT "UserCategoryMapping_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -74,6 +74,7 @@ model User {
   imports                   Import[]
   importedTransactions      ImportedTransaction[]
   autoApproveRules          AutoApproveRule[]
+  categoryMappings          UserCategoryMapping[]
 }
 
 model UserNotificationPreference {
@@ -164,6 +165,7 @@ model Category {
   transactions          Transaction[]
   scheduledTransactions ScheduledTransaction[]
   autoApproveRules      AutoApproveRule[]
+  categoryMappings      UserCategoryMapping[]
 }
 
 model ScheduledTransaction {
@@ -198,6 +200,21 @@ model TransactionFile {
 
   @@index([transactionId])
   @@index([status])
+}
+
+model UserCategoryMapping {
+  id                 String   @id @default(uuid()) @db.Uuid
+  userId             String   @db.Uuid
+  descriptionPattern String
+  categoryId         String   @db.Uuid
+  hitCount           Int      @default(1)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  user               User     @relation(fields: [userId], references: [id])
+  category           Category @relation(fields: [categoryId], references: [id])
+
+  @@unique([userId, descriptionPattern])
+  @@index([userId])
 }
 
 model AutoApproveRule {

--- a/src/repositories/userCategoryMappingRepository.ts
+++ b/src/repositories/userCategoryMappingRepository.ts
@@ -1,0 +1,38 @@
+import prisma from '../prisma/client';
+
+class UserCategoryMappingRepository {
+  async findByUserAndDescription(
+    userId: string,
+    descriptionPattern: string,
+  ): Promise<{ categoryId: string } | null> {
+    return prisma.userCategoryMapping.findUnique({
+      where: {
+        userId_descriptionPattern: { userId, descriptionPattern },
+      },
+      select: { categoryId: true },
+    });
+  }
+
+  async upsert(
+    userId: string,
+    descriptionPattern: string,
+    categoryId: string,
+  ): Promise<void> {
+    await prisma.userCategoryMapping.upsert({
+      where: {
+        userId_descriptionPattern: { userId, descriptionPattern },
+      },
+      update: {
+        categoryId,
+        hitCount: { increment: 1 },
+      },
+      create: {
+        userId,
+        descriptionPattern,
+        categoryId,
+      },
+    });
+  }
+}
+
+export default new UserCategoryMappingRepository();

--- a/src/services/ai/aiProvider.ts
+++ b/src/services/ai/aiProvider.ts
@@ -1,6 +1,11 @@
 import { Category } from '../../types/category';
 import { Transaction } from '../../types/transaction';
 
+export interface CategorizerHint {
+  hint: string;
+  confidence: number;
+}
+
 export interface AIProvider {
   generateContent(prompt: string): Promise<string>;
   analyzeExpenses(
@@ -10,6 +15,7 @@ export interface AIProvider {
   suggestCategory(
     expenseDescription: string,
     categoryOptions: Category[],
+    categorizerHint?: CategorizerHint,
   ): Promise<string>;
   findMatchingTransaction(
     importedDescription: string,

--- a/src/services/ai/chatGPTService.ts
+++ b/src/services/ai/chatGPTService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { AIProvider } from 'services/ai/aiProvider';
+import { AIProvider, CategorizerHint } from 'services/ai/aiProvider';
 import { Category } from 'types/category';
 import { Transaction } from 'types/transaction';
 
@@ -63,8 +63,17 @@ export class ChatGPTService implements AIProvider {
   async suggestCategory(
     expenseDescription: string,
     categoryOptions: Category[],
+    categorizerHint?: CategorizerHint,
   ): Promise<string> {
     try {
+      let userContent = `Which category does this expense belong to?\n\n"${expenseDescription}"\n\nAvailable categories:\n${categoryOptions.map((c) => `- ${c.name}`).join('\n')}`;
+
+      if (categorizerHint) {
+        userContent += `\n\nA machine learning model suggested "${categorizerHint.hint}" with ${Math.round(categorizerHint.confidence * 100)}% confidence. Consider this suggestion but use your own judgment.`;
+      }
+
+      userContent += '\n\nReturn only the category name, nothing else.';
+
       const response = await this.openai.chat.completions.create({
         model: 'gpt-4-turbo',
         messages: [
@@ -75,16 +84,13 @@ export class ChatGPTService implements AIProvider {
           },
           {
             role: 'user',
-            content: `Which category does this expense belong to?\n\n"${expenseDescription}", here are the available options:\n${categoryOptions.map(
-              (category) =>
-                `- ${category.name}\n, return only the category name`,
-            )}`,
+            content: userContent,
           },
         ],
         max_tokens: 50,
       });
 
-      const aiSuggestedCategory = response.choices[0].message?.content;
+      const aiSuggestedCategory = response.choices[0].message?.content?.trim();
 
       const suggestedCategory = categoryOptions.find(
         (category) => category.name === aiSuggestedCategory,

--- a/src/services/ai/geminiService.ts
+++ b/src/services/ai/geminiService.ts
@@ -1,5 +1,5 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { AIProvider } from './aiProvider';
+import { AIProvider, CategorizerHint } from './aiProvider';
 import logger from '../../utils/logger';
 import { Category } from '../../types/category';
 import { Transaction } from '../../types/transaction';
@@ -72,24 +72,27 @@ export class GeminiService implements AIProvider {
   async suggestCategory(
     expenseDescription: string,
     categoryOptions: Category[],
+    categorizerHint?: CategorizerHint,
   ): Promise<string> {
     try {
       logger.debug(
         `Start suggesting category for expense: ${expenseDescription}`,
       );
       const model = this.gemini.getGenerativeModel({ model: this.modelName });
+
+      let promptText = `Which category does this expense belong to?\n\n"${expenseDescription}"\n\nAvailable categories:\n${categoryOptions.map((c) => `- ${c.name}`).join('\n')}`;
+
+      if (categorizerHint) {
+        promptText += `\n\nA machine learning model suggested "${categorizerHint.hint}" with ${Math.round(categorizerHint.confidence * 100)}% confidence. Consider this suggestion but use your own judgment.`;
+      }
+
+      promptText += '\n\nReturn only the category name, nothing else.';
+
       const response = await model.generateContent({
         contents: [
           {
             role: 'user',
-            parts: [
-              {
-                text: `Which category does this expense belong to?\n\n"${expenseDescription}", here are the available options:\n${categoryOptions.map(
-                  (category) =>
-                    `- ${category.name}\n, return only the category name`,
-                )}`,
-              },
-            ],
+            parts: [{ text: promptText }],
           },
         ],
       });

--- a/src/services/transactionManager.ts
+++ b/src/services/transactionManager.ts
@@ -173,7 +173,7 @@ class TransactionManager {
       ? new Date()
       : new Date(sanitizedText);
 
-    const createdTransaction = await TransactionService.createTransaction({
+    const createdResult = await TransactionService.createTransaction({
       type: inProcessTransaction.type as TransactionType,
       value: inProcessTransaction.value as number,
       description: inProcessTransaction.description as string,
@@ -183,7 +183,7 @@ class TransactionManager {
     });
 
     const transaction = await TransactionService.getTransactionItem(
-      createdTransaction,
+      createdResult.id,
       userId,
     );
 

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -3,6 +3,7 @@ import transactionRepository from '../repositories/transactionRepository';
 import transactionFileRepository from '../repositories/transactionFileRepository';
 import {
   CreateTransaction,
+  CreateTransactionResult,
   TransactionFilters,
   Transaction,
   TransactionSummaryFilters,
@@ -18,6 +19,7 @@ import logger from '../utils/logger';
 import { Category } from '../types/category';
 import TransactionNotifierFactory from './transactionNotification/transactionNotifierFactory';
 import userSettingsService from '../services/userSettingsService';
+import userCategoryMappingRepository from '../repositories/userCategoryMappingRepository';
 import {
   buildPreviewUrl,
   buildDownloadUrl,
@@ -28,7 +30,10 @@ class TransactionService {
   private aiService = aiServiceFactory.getAIService();
   private transactionNotifier = TransactionNotifierFactory.getNotifier();
 
-  public async createTransaction(data: CreateTransaction): Promise<string> {
+  public async createTransaction(
+    data: CreateTransaction,
+  ): Promise<CreateTransactionResult> {
+    const userProvidedCategory = !!data.categoryId;
     const createTransaction = await this.updateCategory(data);
     await createTransactionValidator.validate(createTransaction);
     const CreateTransactionDbModel = {
@@ -49,7 +54,19 @@ class TransactionService {
       createTransaction.userId,
     );
 
-    return transactionId;
+    const result: CreateTransactionResult = { id: transactionId };
+
+    if (!userProvidedCategory && createTransaction.categoryId) {
+      const categories = await categoryRepository.getAllCategories();
+      const cat = categories.find(
+        (c) => c.id === createTransaction.categoryId,
+      );
+      if (cat) {
+        result.suggestedCategory = { id: cat.id, name: cat.name };
+      }
+    }
+
+    return result;
   }
 
   public async getTransactions(
@@ -129,6 +146,29 @@ class TransactionService {
     data: CreateTransactionRequest,
     userId: string,
   ): Promise<void> {
+    if (data.categoryId) {
+      try {
+        const existing = await transactionRepository.getTransactionItem(
+          id,
+          userId,
+        );
+        if (existing && existing.category.id !== data.categoryId) {
+          const normalizedDescription = existing.description
+            .toLowerCase()
+            .trim();
+          await userCategoryMappingRepository.upsert(
+            userId,
+            normalizedDescription,
+            data.categoryId,
+          );
+          logger.debug(
+            `Saved category mapping: "${normalizedDescription}" -> ${data.categoryId}`,
+          );
+        }
+      } catch (err) {
+        logger.warn(`Failed to save category mapping on update: ${err}`);
+      }
+    }
     await transactionRepository.updateTransaction(id, data, userId);
   }
 
@@ -220,6 +260,7 @@ class TransactionService {
 
     const suggestedCategoryId = await this.getSuggestedCategory(
       transaction.description,
+      transaction.userId,
       categories,
     );
 
@@ -231,35 +272,78 @@ class TransactionService {
 
   private async getSuggestedCategory(
     description: string,
+    userId: string,
     categories: Category[],
   ): Promise<string> {
-    let categoryFoundUsingCategorizer = false;
-    let category: string | null = null;
+    // 1. Check user category mappings first (learned from corrections)
     try {
-      category = await this.categorizeExpense(description);
-
-      if (category && categories.find((c) => c.name === category)) {
-        categoryFoundUsingCategorizer = true;
+      const normalizedDescription = description.toLowerCase().trim();
+      const mapping =
+        await userCategoryMappingRepository.findByUserAndDescription(
+          userId,
+          normalizedDescription,
+        );
+      if (mapping) {
+        const cat = categories.find((c) => c.id === mapping.categoryId);
+        if (cat) {
+          logger.debug(
+            `User mapping found for expense: ${description} -> ${cat.name}`,
+          );
+          return cat.id;
+        }
       }
+    } catch (err) {
+      logger.warn(`Failed to check user category mapping: ${err}`);
+    }
+
+    // 2. Try FastText categorizer with confidence routing
+    let categorizerResult: {
+      category: string;
+      confidence: number;
+    } | null = null;
+    try {
+      categorizerResult = await this.categorizeExpense(description);
     } catch (err) {
       logger.warn(`Failed to categorize expense: ${description}`);
     }
 
-    if (categoryFoundUsingCategorizer) {
-      logger.debug(
-        `Categorizer found category for expense: ${description} - ${category}`,
+    if (categorizerResult) {
+      const matchedCategory = categories.find(
+        (c) => c.name === categorizerResult!.category,
       );
-      return categories.find((c) => c.name === category)?.id as string;
+
+      if (matchedCategory && categorizerResult.confidence >= 0.7) {
+        logger.debug(
+          `High confidence (${categorizerResult.confidence.toFixed(2)}) category: ${categorizerResult.category}`,
+        );
+        return matchedCategory.id;
+      }
+
+      if (matchedCategory && categorizerResult.confidence >= 0.4) {
+        logger.debug(
+          `Medium confidence (${categorizerResult.confidence.toFixed(2)}), passing hint to LLM: ${categorizerResult.category}`,
+        );
+        return this.aiService.suggestCategory(
+          description,
+          categories,
+          {
+            hint: categorizerResult.category,
+            confidence: categorizerResult.confidence,
+          },
+        );
+      }
     }
 
+    // 3. Low confidence or no result — LLM fallback without hint
     logger.warn(
-      `No category found for expense using categorizer. Using AI service instead.`,
+      `No reliable category from categorizer for: ${description}. Using AI service.`,
     );
-
     return this.aiService.suggestCategory(description, categories);
   }
 
-  private async categorizeExpense(description: string): Promise<string | null> {
+  private async categorizeExpense(
+    description: string,
+  ): Promise<{ category: string; confidence: number } | null> {
     const expenseCategorizerBaseUrl = process.env.EXPENSE_CATEGORIZER_BASE_URL;
     const response = await axios.post(`${expenseCategorizerBaseUrl}/predict`, {
       description,
@@ -271,7 +355,10 @@ class TransactionService {
       return null;
     }
 
-    return response.data.category;
+    return {
+      category: response.data.category,
+      confidence: response.data.confidence ?? 0,
+    };
   }
 
   private async notifyTransactionCreatedSafe(

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -67,5 +67,13 @@ export interface TransactionSummary {
   totalExpense: number;
 }
 
+export interface CreateTransactionResult {
+  id: string;
+  suggestedCategory?: {
+    id: string;
+    name: string;
+  };
+}
+
 //TODO: remove this type and use enum instead
 export type TransactionType = 'INCOME' | 'EXPENSE';


### PR DESCRIPTION
## Summary
- **Confidence-based routing**: FastText categorizer now returns confidence scores. High confidence (≥0.7) accepted directly, medium (0.4-0.7) passed as hint to LLM, low (<0.4) pure LLM fallback
- **Per-user learning**: New `UserCategoryMapping` model learns from user corrections — when a user changes a category, the mapping is saved and checked first on future categorizations
- **Enhanced LLM prompts**: Gemini/ChatGPT receive ML model hints when available, improving accuracy for medium-confidence predictions
- **Enriched create response**: `createTransaction` now returns `suggestedCategory` when AI-assigned, enabling frontend confirmation UX

## Test plan
- [ ] Call `/predict` endpoint with various descriptions — verify confidence + alternatives in response
- [ ] Create transaction without category with a clear description (e.g., "Wolt delivery") — verify high-confidence FastText result is used directly
- [ ] Create transaction with ambiguous description — verify LLM fallback is triggered (check logs)
- [ ] Update a transaction's category — verify `UserCategoryMapping` row is created in DB
- [ ] Create another transaction with the same description — verify the corrected category is used immediately
- [ ] Run `prisma migrate deploy` to apply the `UserCategoryMapping` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)