### PR TITLE
Add DELETE /api/imports/:importId endpoint

### DIFF
--- a/dist/controllers/importController.js
+++ b/dist/controllers/importController.js
@@ -274,6 +274,18 @@ class ImportController {
             throw error;
         }
     }
+    async deleteImport(importId, userId) {
+        try {
+            logger_1.default.debug('Start delete import', { importId, userId });
+            await importService_1.importService.deleteImport(importId, userId);
+            logger_1.default.debug('Done delete import');
+            return { success: true };
+        }
+        catch (error) {
+            logger_1.default.error('Failed to delete import', { importId, userId, error });
+            throw error;
+        }
+    }
     async deleteImportedTransaction(importedTransactionId, userId) {
         try {
             logger_1.default.debug('Start delete imported transaction', {

--- a/dist/repositories/importRepository.js
+++ b/dist/repositories/importRepository.js
@@ -19,7 +19,7 @@ class ImportRepository {
     }
     async findByUserId(userId) {
         return client_2.default.import.findMany({
-            where: { userId },
+            where: { userId, deleted: false },
             orderBy: [{ createdAt: 'desc' }, { paymentMonth: 'desc' }],
             include: {
                 _count: {
@@ -56,6 +56,12 @@ class ImportRepository {
             }
         }
         return null;
+    }
+    async softDelete(id, userId) {
+        await client_2.default.import.update({
+            where: { id, userId },
+            data: { deleted: true },
+        });
     }
     async updateStatus(id, status, error) {
         const data = Object.assign(Object.assign({ status }, (status === client_1.ImportStatus.COMPLETED && { completedAt: new Date() })), (error && { error }));

--- a/dist/routers/importRouter.js
+++ b/dist/routers/importRouter.js
@@ -24,6 +24,7 @@ router.delete('/auto-approve-rules/:ruleId', (0, handleRequest_1.handleRequest)(
     var _a;
     return importController_1.importController.deleteAutoApproveRule(req.params.ruleId, (_a = req.userId) !== null && _a !== void 0 ? _a : '');
 }, 200));
+router.delete('/:importId', (0, handleRequest_1.handleRequest)((req) => { var _a; return importController_1.importController.deleteImport(req.params.importId, (_a = req.userId) !== null && _a !== void 0 ? _a : ''); }, 200));
 router.post('/:importId/apply-auto-approve-rules', (0, handleRequest_1.handleRequest)((req) => {
     var _a;
     return importController_1.importController.applyAutoApproveRules(req.params.importId, (_a = req.userId) !== null && _a !== void 0 ? _a : '');

--- a/dist/services/importService.js
+++ b/dist/services/importService.js
@@ -153,6 +153,9 @@ class ImportService {
     async ignoreImportedTransaction(importedTransactionId, userId) {
         await importedTransactionRepository_1.importedTransactionRepository.updateStatus(importedTransactionId, userId, client_1.ImportedTransactionStatus.IGNORED);
     }
+    async deleteImport(importId, userId) {
+        await importRepository_1.importRepository.softDelete(importId, userId);
+    }
     async deleteImportedTransaction(importedTransactionId, userId) {
         await importedTransactionRepository_1.importedTransactionRepository.softDelete(importedTransactionId, userId);
     }

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -269,6 +269,18 @@ class ImportController {
     }
   }
 
+  async deleteImport(importId: string, userId: string) {
+    try {
+      logger.debug('Start delete import', { importId, userId });
+      await importService.deleteImport(importId, userId);
+      logger.debug('Done delete import');
+      return { success: true };
+    } catch (error) {
+      logger.error('Failed to delete import', { importId, userId, error });
+      throw error;
+    }
+  }
+
   async deleteImportedTransaction(
     importedTransactionId: string,
     userId: string,

--- a/src/prisma/migrations/20260307125158_add_deleted_to_import/migration.sql
+++ b/src/prisma/migrations/20260307125158_add_deleted_to_import/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Import" ADD COLUMN     "deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -128,6 +128,7 @@ model Import {
   
   creditCardLastFourDigits String? /// @encrypted
   paymentMonth             String? // Format: MM/YYYY
+  deleted                  Boolean @default(false)
   excelExtractionRequestId String?
   user                     User    @relation(fields: [userId], references: [id])
 

--- a/src/repositories/importRepository.ts
+++ b/src/repositories/importRepository.ts
@@ -40,7 +40,7 @@ export class ImportRepository {
 
   async findByUserId(userId: string): Promise<ImportWithPendingCount[]> {
     return prisma.import.findMany({
-      where: { userId },
+      where: { userId, deleted: false },
       orderBy: [{ createdAt: 'desc' }, { paymentMonth: 'desc' }],
       include: {
         _count: {
@@ -87,6 +87,13 @@ export class ImportRepository {
     }
 
     return null;
+  }
+
+  async softDelete(id: string, userId: string): Promise<void> {
+    await prisma.import.update({
+      where: { id, userId },
+      data: { deleted: true },
+    });
   }
 
   async updateStatus(

--- a/src/routers/importRouter.ts
+++ b/src/routers/importRouter.ts
@@ -84,6 +84,14 @@ router.delete(
   ),
 );
 
+router.delete(
+  '/:importId',
+  handleRequest(
+    (req) => importController.deleteImport(req.params.importId, req.userId ?? ''),
+    200,
+  ),
+);
+
 router.post(
   '/:importId/apply-auto-approve-rules',
   handleRequest(

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -255,6 +255,10 @@ class ImportService {
     );
   }
 
+  public async deleteImport(importId: string, userId: string) {
+    await importRepository.softDelete(importId, userId);
+  }
+
   public async deleteImportedTransaction(
     importedTransactionId: string,
     userId: string,


### PR DESCRIPTION
## Summary
- The frontend calls `DELETE /api/imports/:importId` to delete imports (e.g. stuck in PROCESSING), but the backend route was never implemented — returning Express's default `Cannot DELETE` 404 HTML
- Adds `deleted` boolean field to the `Import` model (soft-delete pattern, matching `ImportedTransaction`)
- Implements the full endpoint chain: Router → Controller → Service → Repository
- Filters soft-deleted imports from the `GET /api/imports` list query

## Test plan
- [ ] Deploy and verify `DELETE /api/imports/<id>` returns `{ success: true }`
- [ ] Verify stuck PROCESSING imports can be deleted from the Imports tab
- [ ] Verify deleted imports no longer appear in the imports list
- [ ] Verify existing import operations (approve, ignore, merge) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)