### PR TITLE
Add subscription & recurring bill detection

### DIFF
--- a/dist/controllers/requests.js
+++ b/dist/controllers/requests.js
@@ -9,7 +9,7 @@ var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.TestTelegramRequest = exports.UpdateUserSettingsRequest = exports.UserSettingsResponse = exports.NotificationProviderDto = exports.UserSettingsNotificationsDto = exports.UserSettingsInfoDto = exports.SignupRequest = exports.VerifyLoginCodeRequest = exports.LoginRequest = exports.UpdateScheduledTransactionRequest = exports.CreateScheduledTransactionRequest = exports.WebhookRequest = exports.WebhookMessage = exports.WebhookChat = exports.GetTransactionsRequest = exports.GetTransactionsSummaryRequest = exports.UpdateTransactionStatusRequest = exports.UpdateTransactionRequest = exports.CreateTransactionRequest = void 0;
+exports.ConvertSubscriptionRequest = exports.TestTelegramRequest = exports.UpdateUserSettingsRequest = exports.UserSettingsResponse = exports.NotificationProviderDto = exports.UserSettingsNotificationsDto = exports.UserSettingsInfoDto = exports.SignupRequest = exports.VerifyLoginCodeRequest = exports.LoginRequest = exports.UpdateScheduledTransactionRequest = exports.CreateScheduledTransactionRequest = exports.WebhookRequest = exports.WebhookMessage = exports.WebhookChat = exports.GetTransactionsRequest = exports.GetTransactionsSummaryRequest = exports.UpdateTransactionStatusRequest = exports.UpdateTransactionRequest = exports.CreateTransactionRequest = void 0;
 const class_validator_1 = require("class-validator");
 const class_transformer_1 = require("class-transformer");
 //TODO: remove this import and create an enum for schedule types that is not depending on Prisma
@@ -369,6 +369,10 @@ __decorate([
     (0, class_validator_1.IsBoolean)(),
     __metadata("design:type", Boolean)
 ], UserSettingsNotificationsDto.prototype, "dailySummary", void 0);
+__decorate([
+    (0, class_validator_1.IsBoolean)(),
+    __metadata("design:type", Boolean)
+], UserSettingsNotificationsDto.prototype, "subscriptionAudit", void 0);
 class NotificationProviderDto {
 }
 exports.NotificationProviderDto = NotificationProviderDto;
@@ -424,3 +428,10 @@ __decorate([
     (0, class_validator_1.IsNotEmpty)(),
     __metadata("design:type", String)
 ], TestTelegramRequest.prototype, "chatId", void 0);
+class ConvertSubscriptionRequest {
+}
+exports.ConvertSubscriptionRequest = ConvertSubscriptionRequest;
+__decorate([
+    (0, class_validator_1.IsUUID)(),
+    __metadata("design:type", String)
+], ConvertSubscriptionRequest.prototype, "categoryId", void 0);

--- a/dist/controllers/subscriptionController.js
+++ b/dist/controllers/subscriptionController.js
@@ -1,0 +1,68 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const logger_1 = __importDefault(require("../utils/logger"));
+const subscriptionDetectionService_1 = __importDefault(require("../services/subscriptionDetectionService"));
+class SubscriptionController {
+    async list(userId, status) {
+        try {
+            logger_1.default.debug('Start list subscriptions', { userId, status });
+            const validStatus = this.parseStatus(status);
+            const result = await subscriptionDetectionService_1.default.getSubscriptions(userId, validStatus);
+            logger_1.default.debug('Done list subscriptions', { count: result.subscriptions.length });
+            return result;
+        }
+        catch (error) {
+            logger_1.default.error(`Failed to list subscriptions, ${error.message}`);
+            throw error;
+        }
+    }
+    async confirm(id, userId) {
+        try {
+            logger_1.default.debug('Start confirm subscription', { id, userId });
+            const result = await subscriptionDetectionService_1.default.confirmSubscription(id, userId);
+            logger_1.default.debug('Done confirm subscription', { id });
+            return result;
+        }
+        catch (error) {
+            logger_1.default.error(`Failed to confirm subscription ${id}, ${error.message}`);
+            throw error;
+        }
+    }
+    async dismiss(id, userId) {
+        try {
+            logger_1.default.debug('Start dismiss subscription', { id, userId });
+            const result = await subscriptionDetectionService_1.default.dismissSubscription(id, userId);
+            logger_1.default.debug('Done dismiss subscription', { id });
+            return result;
+        }
+        catch (error) {
+            logger_1.default.error(`Failed to dismiss subscription ${id}, ${error.message}`);
+            throw error;
+        }
+    }
+    async convert(id, userId, body) {
+        try {
+            logger_1.default.debug('Start convert subscription', { id, userId, body });
+            const result = await subscriptionDetectionService_1.default.convertToScheduledTransaction(id, userId, body.categoryId);
+            logger_1.default.debug('Done convert subscription', { id });
+            return result;
+        }
+        catch (error) {
+            logger_1.default.error(`Failed to convert subscription ${id}, ${error.message}`);
+            throw error;
+        }
+    }
+    parseStatus(status) {
+        if (!status)
+            return undefined;
+        const upper = status.toUpperCase();
+        if (['DETECTED', 'CONFIRMED', 'DISMISSED'].includes(upper)) {
+            return upper;
+        }
+        return undefined;
+    }
+}
+exports.default = new SubscriptionController();

--- a/dist/controllers/userSettingsController.js
+++ b/dist/controllers/userSettingsController.js
@@ -18,6 +18,7 @@ class UserSettingsController {
                 notifications: {
                     createTransaction: userSettings.notifications.createTransaction,
                     dailySummary: userSettings.notifications.dailySummary,
+                    subscriptionAudit: userSettings.notifications.subscriptionAudit,
                 },
                 provider: {
                     enabled: userSettings.provider.enabled,
@@ -37,6 +38,7 @@ class UserSettingsController {
                 notifications: {
                     createTransaction: settings.notifications.createTransaction,
                     dailySummary: settings.notifications.dailySummary,
+                    subscriptionAudit: settings.notifications.subscriptionAudit,
                 },
                 provider: {
                     enabled: settings.provider.enabled,

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,13 +15,23 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/dist/repositories/subscriptionRepository.js
+++ b/dist/repositories/subscriptionRepository.js
@@ -1,0 +1,143 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const client_1 = __importDefault(require("../prisma/client"));
+class SubscriptionRepository {
+    async getByUserId(userId, status) {
+        const subscriptions = await client_1.default.detectedSubscription.findMany({
+            where: Object.assign({ userId }, (status ? { status } : {})),
+            orderBy: { updatedAt: 'desc' },
+        });
+        return subscriptions.map(this.mapToDomain);
+    }
+    async upsert(data) {
+        const result = await client_1.default.detectedSubscription.upsert({
+            where: {
+                userId_merchantName_frequency: {
+                    userId: data.userId,
+                    merchantName: data.merchantName,
+                    frequency: data.frequency,
+                },
+            },
+            update: {
+                displayName: data.displayName,
+                averageAmount: data.averageAmount,
+                lastChargeDate: data.lastChargeDate,
+                nextExpectedDate: data.nextExpectedDate,
+                annualCost: data.annualCost,
+                matchingDescriptions: data.matchingDescriptions,
+                confidence: data.confidence,
+            },
+            create: {
+                userId: data.userId,
+                merchantName: data.merchantName,
+                displayName: data.displayName,
+                averageAmount: data.averageAmount,
+                frequency: data.frequency,
+                lastChargeDate: data.lastChargeDate,
+                nextExpectedDate: data.nextExpectedDate,
+                annualCost: data.annualCost,
+                matchingDescriptions: data.matchingDescriptions,
+                confidence: data.confidence,
+            },
+        });
+        return this.mapToDomain(result);
+    }
+    async updateStatus(id, userId, status) {
+        const result = await client_1.default.detectedSubscription.update({
+            where: { id, userId },
+            data: { status },
+        });
+        return this.mapToDomain(result);
+    }
+    async linkScheduledTransaction(id, userId, scheduledTransactionId) {
+        const result = await client_1.default.detectedSubscription.update({
+            where: { id, userId },
+            data: { scheduledTransactionId, status: 'CONFIRMED' },
+        });
+        return this.mapToDomain(result);
+    }
+    async getById(id, userId) {
+        const result = await client_1.default.detectedSubscription.findUnique({
+            where: { id, userId },
+        });
+        return result ? this.mapToDomain(result) : null;
+    }
+    async getDismissedMerchants(userId) {
+        const dismissed = await client_1.default.detectedSubscription.findMany({
+            where: { userId, status: 'DISMISSED' },
+            select: { merchantName: true, frequency: true },
+        });
+        return dismissed;
+    }
+    async getAllUserIds() {
+        const users = await client_1.default.user.findMany({
+            select: { id: true },
+        });
+        return users.map((u) => u.id);
+    }
+    async getSnapshotByUserId(userId) {
+        const subscriptions = await client_1.default.detectedSubscription.findMany({
+            where: {
+                userId,
+                status: { in: ['CONFIRMED', 'DETECTED'] },
+            },
+            select: {
+                status: true,
+                averageAmount: true,
+                annualCost: true,
+                frequency: true,
+            },
+        });
+        let activeCount = 0;
+        let detectedCount = 0;
+        let totalMonthlyEstimate = 0;
+        let totalAnnualEstimate = 0;
+        for (const s of subscriptions) {
+            const monthly = s.frequency === 'WEEKLY'
+                ? (s.averageAmount * 52) / 12
+                : s.frequency === 'YEARLY'
+                    ? s.averageAmount / 12
+                    : s.averageAmount;
+            totalMonthlyEstimate += monthly;
+            totalAnnualEstimate += s.annualCost;
+            if (s.status === 'CONFIRMED')
+                activeCount++;
+            else
+                detectedCount++;
+        }
+        return { activeCount, totalMonthlyEstimate, totalAnnualEstimate, detectedCount };
+    }
+    async getActiveForAllUsers() {
+        const subscriptions = await client_1.default.detectedSubscription.findMany({
+            where: {
+                status: { in: ['DETECTED', 'CONFIRMED'] },
+            },
+            orderBy: { userId: 'asc' },
+        });
+        return subscriptions.map(this.mapToDomain);
+    }
+    mapToDomain(db) {
+        var _a;
+        return {
+            id: db.id,
+            userId: db.userId,
+            merchantName: db.merchantName,
+            displayName: db.displayName,
+            averageAmount: db.averageAmount,
+            frequency: db.frequency,
+            lastChargeDate: db.lastChargeDate,
+            nextExpectedDate: db.nextExpectedDate,
+            annualCost: db.annualCost,
+            status: db.status,
+            matchingDescriptions: db.matchingDescriptions,
+            scheduledTransactionId: (_a = db.scheduledTransactionId) !== null && _a !== void 0 ? _a : undefined,
+            confidence: db.confidence,
+            createdAt: db.createdAt,
+            updatedAt: db.updatedAt,
+        };
+    }
+}
+exports.default = new SubscriptionRepository();

--- a/dist/repositories/userRepository.js
+++ b/dist/repositories/userRepository.js
@@ -47,7 +47,7 @@ class UserRepository {
         });
     }
     async getUserSettings(userId) {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e, _f;
         const user = await client_1.default.user.findUnique({
             where: { id: userId },
             select: {
@@ -64,6 +64,7 @@ class UserRepository {
             notifications: {
                 createTransaction: (_b = (_a = user.userNotification) === null || _a === void 0 ? void 0 : _a.createTransaction) !== null && _b !== void 0 ? _b : false,
                 dailySummary: (_d = (_c = user.userNotification) === null || _c === void 0 ? void 0 : _c.dailySummary) !== null && _d !== void 0 ? _d : false,
+                subscriptionAudit: (_f = (_e = user.userNotification) === null || _e === void 0 ? void 0 : _e.subscriptionAudit) !== null && _f !== void 0 ? _f : false,
             },
             providers: user.userNotificationProviders || [],
         };
@@ -74,11 +75,13 @@ class UserRepository {
             update: {
                 createTransaction: notifications.createTransaction,
                 dailySummary: notifications.dailySummary,
+                subscriptionAudit: notifications.subscriptionAudit,
             },
             create: {
                 userId: userId,
                 createTransaction: notifications.createTransaction,
                 dailySummary: notifications.dailySummary,
+                subscriptionAudit: notifications.subscriptionAudit,
             },
         });
         for (const provider of providers) {

--- a/dist/routers/index.js
+++ b/dist/routers/index.js
@@ -16,6 +16,7 @@ const trendRouter_1 = __importDefault(require("./trendRouter"));
 const importRouter_1 = __importDefault(require("./importRouter"));
 const chatRouter_1 = __importDefault(require("./chatRouter"));
 const dashboardRouter_1 = __importDefault(require("./dashboardRouter"));
+const subscriptionRouter_1 = __importDefault(require("./subscriptionRouter"));
 const excelExtractionWebhookController_1 = require("../controllers/excelExtractionWebhookController");
 const router = express_1.default.Router();
 router.use('/api/auth', authRouter_1.default);
@@ -30,6 +31,7 @@ router.use('/api/trends', trendRouter_1.default);
 router.use('/api/imports', importRouter_1.default);
 router.use('/api/chat', chatRouter_1.default);
 router.use('/api/dashboard', dashboardRouter_1.default);
+router.use('/api/subscriptions', subscriptionRouter_1.default);
 router.get('/', (req, res) => {
     res.send('ok');
 });

--- a/dist/routers/subscriptionRouter.js
+++ b/dist/routers/subscriptionRouter.js
@@ -1,0 +1,23 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const subscriptionController_1 = __importDefault(require("../controllers/subscriptionController"));
+const subscriptionDetectionService_1 = __importDefault(require("../services/subscriptionDetectionService"));
+const handleRequest_1 = require("../utils/handleRequest");
+const validation_1 = require("../middlewares/validation");
+const requests_1 = require("../controllers/requests");
+const authMiddleware_1 = require("../middlewares/authMiddleware");
+const router = express_1.default.Router();
+router.get('/detect', (0, handleRequest_1.handleRequest)(() => subscriptionDetectionService_1.default.runDetectionForAllUsers(), 200));
+router.get('/audit-notify', (0, handleRequest_1.handleRequest)(() => subscriptionDetectionService_1.default.sendMonthlyAuditNotifications(), 200));
+router.get('/', authMiddleware_1.authenticateRequest, (0, handleRequest_1.handleRequest)((req) => {
+    var _a;
+    return subscriptionController_1.default.list((_a = req.userId) !== null && _a !== void 0 ? _a : '', req.query.status);
+}, 200));
+router.patch('/:id/confirm', authMiddleware_1.authenticateRequest, (0, handleRequest_1.handleRequest)((req) => { var _a; return subscriptionController_1.default.confirm(req.params.id, (_a = req.userId) !== null && _a !== void 0 ? _a : ''); }, 200));
+router.patch('/:id/dismiss', authMiddleware_1.authenticateRequest, (0, handleRequest_1.handleRequest)((req) => { var _a; return subscriptionController_1.default.dismiss(req.params.id, (_a = req.userId) !== null && _a !== void 0 ? _a : ''); }, 200));
+router.post('/:id/convert', (0, validation_1.validateRequest)(requests_1.ConvertSubscriptionRequest), authMiddleware_1.authenticateRequest, (0, handleRequest_1.handleRequest)((req) => { var _a; return subscriptionController_1.default.convert(req.params.id, (_a = req.userId) !== null && _a !== void 0 ? _a : '', req.body); }, 200));
+exports.default = router;

--- a/dist/scripts/createCategorizerDataSetForCsv.js
+++ b/dist/scripts/createCategorizerDataSetForCsv.js
@@ -15,13 +15,23 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/dist/scripts/importTransactionsFromCsv.js
+++ b/dist/scripts/importTransactionsFromCsv.js
@@ -15,13 +15,23 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/dist/services/dashboardService.js
+++ b/dist/services/dashboardService.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const aiServiceFactory_1 = __importDefault(require("./ai/aiServiceFactory"));
 const dashboardRepository_1 = __importDefault(require("../repositories/dashboardRepository"));
+const subscriptionDetectionService_1 = __importDefault(require("./subscriptionDetectionService"));
 const logger_1 = __importDefault(require("../utils/logger"));
 const redisProvider_1 = require("../common/redisProvider");
 class DashboardService {
@@ -18,16 +19,17 @@ class DashboardService {
         const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
         const prevYear = prevDate.getFullYear();
         const prevMonth = prevDate.getMonth() + 1;
-        const [currentMonthSummary, previousMonthSummary, topCategoriesCurrent, topCategoriesPrevious, recentTransactions,] = await Promise.all([
+        const [currentMonthSummary, previousMonthSummary, topCategoriesCurrent, topCategoriesPrevious, recentTransactions, subscriptionSnapshot,] = await Promise.all([
             dashboardRepository_1.default.getMonthSummary(userId, currentYear, currentMonth),
             dashboardRepository_1.default.getMonthSummary(userId, prevYear, prevMonth),
             dashboardRepository_1.default.getTopCategoriesForMonth(userId, currentYear, currentMonth, 7),
             dashboardRepository_1.default.getTopCategoriesForMonth(userId, prevYear, prevMonth, 7),
             dashboardRepository_1.default.getRecentTransactions(userId, 5),
+            subscriptionDetectionService_1.default.getDashboardSnapshot(userId),
         ]);
         const monthComparison = this.buildMonthComparison(currentMonthSummary, previousMonthSummary);
         const topCategories = this.mergeTopCategories(topCategoriesCurrent, topCategoriesPrevious, currentMonthSummary.totalExpense);
-        return { monthComparison, topCategories, recentTransactions };
+        return { monthComparison, topCategories, recentTransactions, subscriptions: subscriptionSnapshot };
     }
     async getInsights(userId) {
         const now = new Date();

--- a/dist/services/subscriptionDetectionService.js
+++ b/dist/services/subscriptionDetectionService.js
@@ -1,0 +1,283 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const date_fns_1 = require("date-fns");
+const client_1 = __importDefault(require("../prisma/client"));
+const subscriptionRepository_1 = __importDefault(require("../repositories/subscriptionRepository"));
+const scheduledTransactionService_1 = __importDefault(require("./scheduledTransactionService"));
+const transactionNotifierFactory_1 = __importDefault(require("./transactionNotification/transactionNotifierFactory"));
+const merchantNormalizer_1 = require("../utils/merchantNormalizer");
+const logger_1 = __importDefault(require("../utils/logger"));
+class SubscriptionDetectionService {
+    async runDetectionForAllUsers() {
+        const userIds = await subscriptionRepository_1.default.getAllUserIds();
+        for (const userId of userIds) {
+            try {
+                await this.detectForUser(userId);
+            }
+            catch (error) {
+                logger_1.default.error(`Subscription detection failed for user ${userId}`, error);
+            }
+        }
+    }
+    async getSubscriptions(userId, status) {
+        const subscriptions = await subscriptionRepository_1.default.getByUserId(userId, status);
+        let totalMonthlyEstimate = 0;
+        let totalAnnualEstimate = 0;
+        let activeCount = 0;
+        let detectedCount = 0;
+        for (const s of subscriptions) {
+            if (s.status === 'CONFIRMED') {
+                activeCount++;
+                totalMonthlyEstimate += this.toMonthlyAmount(s.averageAmount, s.frequency);
+                totalAnnualEstimate += s.annualCost;
+            }
+            else if (s.status === 'DETECTED') {
+                detectedCount++;
+                totalMonthlyEstimate += this.toMonthlyAmount(s.averageAmount, s.frequency);
+                totalAnnualEstimate += s.annualCost;
+            }
+        }
+        return {
+            totalMonthlyEstimate,
+            totalAnnualEstimate,
+            activeCount,
+            detectedCount,
+            subscriptions,
+        };
+    }
+    async confirmSubscription(id, userId) {
+        return subscriptionRepository_1.default.updateStatus(id, userId, 'CONFIRMED');
+    }
+    async dismissSubscription(id, userId) {
+        return subscriptionRepository_1.default.updateStatus(id, userId, 'DISMISSED');
+    }
+    async convertToScheduledTransaction(id, userId, categoryId) {
+        const subscription = await subscriptionRepository_1.default.getById(id, userId);
+        if (!subscription) {
+            throw new Error('Subscription not found');
+        }
+        const scheduledId = await scheduledTransactionService_1.default.createScheduledTransaction({
+            description: subscription.displayName,
+            value: subscription.averageAmount,
+            type: 'EXPENSE',
+            categoryId,
+            scheduleType: subscription.frequency,
+            userId,
+            dayOfMonth: subscription.frequency === 'MONTHLY' ? subscription.lastChargeDate.getDate() : undefined,
+            dayOfWeek: subscription.frequency === 'WEEKLY' ? subscription.lastChargeDate.getDay() : undefined,
+        });
+        return subscriptionRepository_1.default.linkScheduledTransaction(id, userId, scheduledId);
+    }
+    async getDashboardSnapshot(userId) {
+        return subscriptionRepository_1.default.getSnapshotByUserId(userId);
+    }
+    async sendMonthlyAuditNotifications() {
+        const allActive = await subscriptionRepository_1.default.getActiveForAllUsers();
+        const byUser = new Map();
+        for (const sub of allActive) {
+            const existing = byUser.get(sub.userId) || [];
+            existing.push(sub);
+            byUser.set(sub.userId, existing);
+        }
+        const userIds = Array.from(byUser.keys());
+        const allPrefs = await client_1.default.userNotificationPreference.findMany({
+            where: { userId: { in: userIds }, subscriptionAudit: true },
+        });
+        const enabledUserIds = new Set(allPrefs.map((p) => p.userId));
+        const notifier = transactionNotifierFactory_1.default.getNotifier();
+        for (const [userId, subs] of byUser) {
+            try {
+                if (!enabledUserIds.has(userId))
+                    continue;
+                const confirmed = subs.filter((s) => s.status === 'CONFIRMED');
+                const detected = subs.filter((s) => s.status === 'DETECTED');
+                if (confirmed.length === 0 && detected.length === 0)
+                    continue;
+                const now = new Date();
+                const monthName = now.toLocaleString('en-US', { month: 'long' });
+                const year = now.getFullYear();
+                const lines = [`Subscription Audit — ${monthName} ${year}`, ''];
+                if (confirmed.length > 0) {
+                    lines.push('Active Subscriptions:');
+                    let totalMonthly = 0;
+                    let totalAnnual = 0;
+                    for (const sub of confirmed) {
+                        const monthly = this.toMonthlyAmount(sub.averageAmount, sub.frequency);
+                        totalMonthly += monthly;
+                        totalAnnual += sub.annualCost;
+                        lines.push(`- ${sub.displayName}: $${monthly.toFixed(2)}/mo ($${sub.annualCost.toFixed(2)}/yr)`);
+                    }
+                    lines.push('');
+                    lines.push(`Total: $${totalMonthly.toFixed(2)}/month | $${totalAnnual.toFixed(2)}/year`);
+                }
+                if (detected.length > 0) {
+                    lines.push(`${detected.length} new subscription${detected.length > 1 ? 's' : ''} detected — review in app`);
+                }
+                await notifier.sendDailySummary(lines.join('\n'), userId);
+            }
+            catch (error) {
+                logger_1.default.error(`Failed to send subscription audit for user ${userId}`, error);
+            }
+        }
+    }
+    async detectForUser(userId) {
+        const twelveMonthsAgo = new Date();
+        twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12);
+        const transactions = await client_1.default.transaction.findMany({
+            where: {
+                userId,
+                type: 'EXPENSE',
+                status: 'APPROVED',
+                date: { gte: twelveMonthsAgo },
+            },
+            orderBy: { date: 'asc' },
+        });
+        const groups = this.groupByMerchant(transactions);
+        const dismissed = await subscriptionRepository_1.default.getDismissedMerchants(userId);
+        const dismissedSet = new Set(dismissed.map((d) => `${d.merchantName}:${d.frequency}`));
+        for (const group of groups) {
+            if (group.dates.length < 3)
+                continue;
+            const pattern = this.analyzePattern(group);
+            if (!pattern)
+                continue;
+            if (dismissedSet.has(`${pattern.merchantKey}:${pattern.frequency}`)) {
+                continue;
+            }
+            await subscriptionRepository_1.default.upsert({
+                userId,
+                merchantName: pattern.merchantKey,
+                displayName: pattern.displayName,
+                averageAmount: pattern.averageAmount,
+                frequency: pattern.frequency,
+                lastChargeDate: pattern.lastChargeDate,
+                nextExpectedDate: pattern.nextExpectedDate,
+                annualCost: pattern.annualCost,
+                matchingDescriptions: pattern.descriptions,
+                confidence: pattern.confidence,
+            });
+        }
+    }
+    groupByMerchant(transactions) {
+        const groups = new Map();
+        for (const tx of transactions) {
+            const key = (0, merchantNormalizer_1.normalizeMerchantName)(tx.description);
+            if (!key)
+                continue;
+            const existing = groups.get(key);
+            if (existing) {
+                existing.descriptions.push(tx.description);
+                existing.amounts.push(tx.value);
+                existing.dates.push(tx.date);
+            }
+            else {
+                groups.set(key, {
+                    merchantKey: key,
+                    descriptions: [tx.description],
+                    amounts: [tx.value],
+                    dates: [tx.date],
+                });
+            }
+        }
+        return Array.from(groups.values());
+    }
+    analyzePattern(group) {
+        const sortedDates = [...group.dates].sort((a, b) => a.getTime() - b.getTime());
+        const intervals = [];
+        for (let i = 1; i < sortedDates.length; i++) {
+            const diffDays = (sortedDates[i].getTime() - sortedDates[i - 1].getTime()) /
+                (1000 * 60 * 60 * 24);
+            intervals.push(diffDays);
+        }
+        if (intervals.length === 0)
+            return null;
+        const sorted = [...intervals].sort((a, b) => a - b);
+        const median = sorted.length % 2 === 0
+            ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+            : sorted[Math.floor(sorted.length / 2)];
+        const variance = intervals.reduce((sum, v) => sum + Math.pow(v - median, 2), 0) /
+            intervals.length;
+        const stddev = Math.sqrt(variance);
+        const frequency = this.classifyFrequency(median);
+        if (!frequency)
+            return null;
+        if (median > 0 && stddev / median > 0.3)
+            return null;
+        const confidence = Math.max(0, Math.min(1, 1 - stddev / median));
+        const averageAmount = group.amounts.reduce((sum, a) => sum + a, 0) / group.amounts.length;
+        const lastChargeDate = sortedDates[sortedDates.length - 1];
+        const nextExpectedDate = this.calculateNextExpectedDate(lastChargeDate, frequency);
+        const annualCost = this.calculateAnnualCost(averageAmount, frequency);
+        const displayName = this.pickDisplayName(group.descriptions);
+        return {
+            merchantKey: group.merchantKey,
+            displayName,
+            frequency,
+            averageAmount: Math.round(averageAmount * 100) / 100,
+            lastChargeDate,
+            nextExpectedDate,
+            annualCost: Math.round(annualCost * 100) / 100,
+            descriptions: [...new Set(group.descriptions)],
+            confidence: Math.round(confidence * 100) / 100,
+        };
+    }
+    classifyFrequency(medianDays) {
+        if (medianDays >= 5 && medianDays <= 9)
+            return 'WEEKLY';
+        if (medianDays >= 25 && medianDays <= 35)
+            return 'MONTHLY';
+        if (medianDays >= 340 && medianDays <= 395)
+            return 'YEARLY';
+        return null;
+    }
+    calculateNextExpectedDate(lastDate, frequency) {
+        switch (frequency) {
+            case 'WEEKLY':
+                return (0, date_fns_1.addWeeks)(lastDate, 1);
+            case 'MONTHLY':
+                return (0, date_fns_1.addMonths)(lastDate, 1);
+            case 'YEARLY':
+                return (0, date_fns_1.addYears)(lastDate, 1);
+        }
+    }
+    calculateAnnualCost(amount, frequency) {
+        switch (frequency) {
+            case 'WEEKLY':
+                return amount * 52;
+            case 'MONTHLY':
+                return amount * 12;
+            case 'YEARLY':
+                return amount;
+        }
+    }
+    toMonthlyAmount(amount, frequency) {
+        switch (frequency) {
+            case 'WEEKLY':
+                return (amount * 52) / 12;
+            case 'MONTHLY':
+                return amount;
+            case 'YEARLY':
+                return amount / 12;
+        }
+    }
+    pickDisplayName(descriptions) {
+        const descriptionCounts = new Map();
+        for (const desc of descriptions) {
+            const trimmed = desc.trim();
+            descriptionCounts.set(trimmed, (descriptionCounts.get(trimmed) || 0) + 1);
+        }
+        let mostCommon = descriptions[0];
+        let maxCount = 0;
+        for (const [desc, count] of descriptionCounts) {
+            if (count > maxCount) {
+                maxCount = count;
+                mostCommon = desc;
+            }
+        }
+        return (0, merchantNormalizer_1.toDisplayName)(mostCommon);
+    }
+}
+exports.default = new SubscriptionDetectionService();

--- a/dist/services/userSettingsService.js
+++ b/dist/services/userSettingsService.js
@@ -24,6 +24,7 @@ class UserSettingsService {
             notifications: {
                 createTransaction: userSettings.notifications.createTransaction,
                 dailySummary: userSettings.notifications.dailySummary,
+                subscriptionAudit: userSettings.notifications.subscriptionAudit,
             },
             provider: {
                 enabled: (_b = (_a = userSettings.providers[0]) === null || _a === void 0 ? void 0 : _a.enabled) !== null && _b !== void 0 ? _b : false,

--- a/dist/types/subscription.js
+++ b/dist/types/subscription.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/utils/merchantNormalizer.js
+++ b/dist/utils/merchantNormalizer.js
@@ -1,0 +1,25 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.normalizeMerchantName = normalizeMerchantName;
+exports.toDisplayName = toDisplayName;
+const SUFFIX_PATTERN = /\b(inc|ltd|llc|com|co|corp|corporation|limited)\b/gi;
+const TRAILING_DIGITS = /\d+$/;
+const SPECIAL_CHARS = /[*#\-_.]/g;
+const MULTIPLE_SPACES = /\s{2,}/g;
+function normalizeMerchantName(description) {
+    return description
+        .toLowerCase()
+        .trim()
+        .replace(SUFFIX_PATTERN, '')
+        .replace(TRAILING_DIGITS, '')
+        .replace(SPECIAL_CHARS, ' ')
+        .replace(MULTIPLE_SPACES, ' ')
+        .trim();
+}
+function toDisplayName(description) {
+    return description
+        .trim()
+        .split(/\s+/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' ');
+}

--- a/src/controllers/requests.ts
+++ b/src/controllers/requests.ts
@@ -299,6 +299,9 @@ export class UserSettingsNotificationsDto {
 
   @IsBoolean()
   dailySummary: boolean;
+
+  @IsBoolean()
+  subscriptionAudit: boolean;
 }
 
 export class NotificationProviderDto {
@@ -341,4 +344,9 @@ export class TestTelegramRequest {
   @IsString()
   @IsNotEmpty()
   chatId: string;
+}
+
+export class ConvertSubscriptionRequest {
+  @IsUUID()
+  categoryId: string;
 }

--- a/src/controllers/subscriptionController.ts
+++ b/src/controllers/subscriptionController.ts
@@ -1,0 +1,84 @@
+import logger from '../utils/logger';
+import subscriptionDetectionService from '../services/subscriptionDetectionService';
+import { SubscriptionStatus } from '@prisma/client';
+import { ConvertSubscriptionRequest } from './requests';
+
+class SubscriptionController {
+  public async list(userId: string, status?: string) {
+    try {
+      logger.debug('Start list subscriptions', { userId, status });
+      const validStatus = this.parseStatus(status);
+      const result = await subscriptionDetectionService.getSubscriptions(
+        userId,
+        validStatus,
+      );
+      logger.debug('Done list subscriptions', { count: result.subscriptions.length });
+      return result;
+    } catch (error: any) {
+      logger.error(`Failed to list subscriptions, ${error.message}`);
+      throw error;
+    }
+  }
+
+  public async confirm(id: string, userId: string) {
+    try {
+      logger.debug('Start confirm subscription', { id, userId });
+      const result = await subscriptionDetectionService.confirmSubscription(
+        id,
+        userId,
+      );
+      logger.debug('Done confirm subscription', { id });
+      return result;
+    } catch (error: any) {
+      logger.error(`Failed to confirm subscription ${id}, ${error.message}`);
+      throw error;
+    }
+  }
+
+  public async dismiss(id: string, userId: string) {
+    try {
+      logger.debug('Start dismiss subscription', { id, userId });
+      const result = await subscriptionDetectionService.dismissSubscription(
+        id,
+        userId,
+      );
+      logger.debug('Done dismiss subscription', { id });
+      return result;
+    } catch (error: any) {
+      logger.error(`Failed to dismiss subscription ${id}, ${error.message}`);
+      throw error;
+    }
+  }
+
+  public async convert(
+    id: string,
+    userId: string,
+    body: ConvertSubscriptionRequest,
+  ) {
+    try {
+      logger.debug('Start convert subscription', { id, userId, body });
+      const result =
+        await subscriptionDetectionService.convertToScheduledTransaction(
+          id,
+          userId,
+          body.categoryId,
+        );
+      logger.debug('Done convert subscription', { id });
+      return result;
+    } catch (error: any) {
+      logger.error(`Failed to convert subscription ${id}, ${error.message}`);
+      throw error;
+    }
+  }
+
+  private parseStatus(status?: string): SubscriptionStatus | undefined {
+    if (!status) return undefined;
+    const upper = status.toUpperCase();
+    if (['DETECTED', 'CONFIRMED', 'DISMISSED'].includes(upper)) {
+      return upper as SubscriptionStatus;
+    }
+    return undefined;
+  }
+}
+
+export default new SubscriptionController();

--- a/src/controllers/userSettingsController.ts
+++ b/src/controllers/userSettingsController.ts
@@ -16,6 +16,7 @@ class UserSettingsController {
         notifications: {
           createTransaction: userSettings.notifications.createTransaction,
           dailySummary: userSettings.notifications.dailySummary,
+          subscriptionAudit: userSettings.notifications.subscriptionAudit,
         },
         provider: {
           enabled: userSettings.provider.enabled,
@@ -38,6 +39,7 @@ class UserSettingsController {
         notifications: {
           createTransaction: settings.notifications.createTransaction,
           dailySummary: settings.notifications.dailySummary,
+          subscriptionAudit: settings.notifications.subscriptionAudit,
         },
         provider: {
           enabled: settings.provider.enabled,

--- a/src/prisma/migrations/20260313142224_add_detected_subscriptions/migration.sql
+++ b/src/prisma/migrations/20260313142224_add_detected_subscriptions/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "SubscriptionStatus" AS ENUM ('DETECTED', 'CONFIRMED', 'DISMISSED');
+
+-- CreateEnum
+CREATE TYPE "SubscriptionFrequency" AS ENUM ('WEEKLY', 'MONTHLY', 'YEARLY');
+
+-- AlterTable
+ALTER TABLE "UserNotificationPreference" ADD COLUMN     "subscriptionAudit" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "DetectedSubscription" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "merchantName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "averageAmount" DOUBLE PRECISION NOT NULL,
+    "frequency" "SubscriptionFrequency" NOT NULL,
+    "lastChargeDate" TIMESTAMP(3) NOT NULL,
+    "nextExpectedDate" TIMESTAMP(3) NOT NULL,
+    "annualCost" DOUBLE PRECISION NOT NULL,
+    "status" "SubscriptionStatus" NOT NULL DEFAULT 'DETECTED',
+    "matchingDescriptions" TEXT[],
+    "scheduledTransactionId" UUID,
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DetectedSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DetectedSubscription_userId_idx" ON "DetectedSubscription"("userId");
+
+-- CreateIndex
+CREATE INDEX "DetectedSubscription_status_idx" ON "DetectedSubscription"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DetectedSubscription_userId_merchantName_frequency_key" ON "DetectedSubscription"("userId", "merchantName", "frequency");
+
+-- AddForeignKey
+ALTER TABLE "DetectedSubscription" ADD CONSTRAINT "DetectedSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -48,6 +48,18 @@ enum ImportBankSourceType {
   BANK_CREDIT
 }
 
+enum SubscriptionStatus {
+  DETECTED
+  CONFIRMED
+  DISMISSED
+}
+
+enum SubscriptionFrequency {
+  WEEKLY
+  MONTHLY
+  YEARLY
+}
+
 enum ImportedTransactionStatus {
   PENDING
   APPROVED
@@ -75,6 +87,7 @@ model User {
   importedTransactions      ImportedTransaction[]
   autoApproveRules          AutoApproveRule[]
   categoryMappings          UserCategoryMapping[]
+  detectedSubscriptions     DetectedSubscription[]
 }
 
 model UserNotificationPreference {
@@ -82,6 +95,7 @@ model UserNotificationPreference {
   user               User     @relation(fields: [userId], references: [id])
   createTransaction  Boolean  @default(false)
   dailySummary       Boolean  @default(false)
+  subscriptionAudit  Boolean  @default(false)
 }
 
 model UserNotificationProvider {
@@ -231,4 +245,28 @@ model AutoApproveRule {
   category           Category        @relation(fields: [categoryId], references: [id])
 
   @@index([userId])
+}
+
+model DetectedSubscription {
+  id                     String                @id @default(uuid()) @db.Uuid
+  userId                 String                @db.Uuid
+  merchantName           String
+  displayName            String
+  averageAmount          Float
+  frequency              SubscriptionFrequency
+  lastChargeDate         DateTime
+  nextExpectedDate       DateTime
+  annualCost             Float
+  status                 SubscriptionStatus    @default(DETECTED)
+  matchingDescriptions   String[]
+  scheduledTransactionId String?               @db.Uuid
+  confidence             Float                 @default(0)
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+
+  user                   User                  @relation(fields: [userId], references: [id])
+
+  @@unique([userId, merchantName, frequency])
+  @@index([userId])
+  @@index([status])
 }

--- a/src/repositories/subscriptionRepository.ts
+++ b/src/repositories/subscriptionRepository.ts
@@ -1,0 +1,188 @@
+import { SubscriptionStatus, SubscriptionFrequency } from '@prisma/client';
+import prisma from '../prisma/client';
+import {
+  DetectedSubscriptionDomain,
+  SubscriptionDashboardSnapshot,
+} from '../types/subscription';
+
+class SubscriptionRepository {
+  public async getByUserId(
+    userId: string,
+    status?: SubscriptionStatus,
+  ): Promise<DetectedSubscriptionDomain[]> {
+    const subscriptions = await prisma.detectedSubscription.findMany({
+      where: {
+        userId,
+        ...(status ? { status } : {}),
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+    return subscriptions.map(this.mapToDomain);
+  }
+
+  public async upsert(data: {
+    userId: string;
+    merchantName: string;
+    displayName: string;
+    averageAmount: number;
+    frequency: SubscriptionFrequency;
+    lastChargeDate: Date;
+    nextExpectedDate: Date;
+    annualCost: number;
+    matchingDescriptions: string[];
+    confidence: number;
+  }): Promise<DetectedSubscriptionDomain> {
+    const result = await prisma.detectedSubscription.upsert({
+      where: {
+        userId_merchantName_frequency: {
+          userId: data.userId,
+          merchantName: data.merchantName,
+          frequency: data.frequency,
+        },
+      },
+      update: {
+        displayName: data.displayName,
+        averageAmount: data.averageAmount,
+        lastChargeDate: data.lastChargeDate,
+        nextExpectedDate: data.nextExpectedDate,
+        annualCost: data.annualCost,
+        matchingDescriptions: data.matchingDescriptions,
+        confidence: data.confidence,
+      },
+      create: {
+        userId: data.userId,
+        merchantName: data.merchantName,
+        displayName: data.displayName,
+        averageAmount: data.averageAmount,
+        frequency: data.frequency,
+        lastChargeDate: data.lastChargeDate,
+        nextExpectedDate: data.nextExpectedDate,
+        annualCost: data.annualCost,
+        matchingDescriptions: data.matchingDescriptions,
+        confidence: data.confidence,
+      },
+    });
+    return this.mapToDomain(result);
+  }
+
+  public async updateStatus(
+    id: string,
+    userId: string,
+    status: SubscriptionStatus,
+  ): Promise<DetectedSubscriptionDomain> {
+    const result = await prisma.detectedSubscription.update({
+      where: { id, userId },
+      data: { status },
+    });
+    return this.mapToDomain(result);
+  }
+
+  public async linkScheduledTransaction(
+    id: string,
+    userId: string,
+    scheduledTransactionId: string,
+  ): Promise<DetectedSubscriptionDomain> {
+    const result = await prisma.detectedSubscription.update({
+      where: { id, userId },
+      data: { scheduledTransactionId, status: 'CONFIRMED' },
+    });
+    return this.mapToDomain(result);
+  }
+
+  public async getById(
+    id: string,
+    userId: string,
+  ): Promise<DetectedSubscriptionDomain | null> {
+    const result = await prisma.detectedSubscription.findUnique({
+      where: { id, userId },
+    });
+    return result ? this.mapToDomain(result) : null;
+  }
+
+  public async getDismissedMerchants(
+    userId: string,
+  ): Promise<{ merchantName: string; frequency: SubscriptionFrequency }[]> {
+    const dismissed = await prisma.detectedSubscription.findMany({
+      where: { userId, status: 'DISMISSED' },
+      select: { merchantName: true, frequency: true },
+    });
+    return dismissed;
+  }
+
+  public async getAllUserIds(): Promise<string[]> {
+    const users = await prisma.user.findMany({
+      select: { id: true },
+    });
+    return users.map((u) => u.id);
+  }
+
+  public async getSnapshotByUserId(
+    userId: string,
+  ): Promise<SubscriptionDashboardSnapshot> {
+    const subscriptions = await prisma.detectedSubscription.findMany({
+      where: {
+        userId,
+        status: { in: ['CONFIRMED', 'DETECTED'] },
+      },
+      select: {
+        status: true,
+        averageAmount: true,
+        annualCost: true,
+        frequency: true,
+      },
+    });
+
+    let activeCount = 0;
+    let detectedCount = 0;
+    let totalMonthlyEstimate = 0;
+    let totalAnnualEstimate = 0;
+
+    for (const s of subscriptions) {
+      const monthly =
+        s.frequency === 'WEEKLY'
+          ? (s.averageAmount * 52) / 12
+          : s.frequency === 'YEARLY'
+            ? s.averageAmount / 12
+            : s.averageAmount;
+      totalMonthlyEstimate += monthly;
+      totalAnnualEstimate += s.annualCost;
+
+      if (s.status === 'CONFIRMED') activeCount++;
+      else detectedCount++;
+    }
+
+    return { activeCount, totalMonthlyEstimate, totalAnnualEstimate, detectedCount };
+  }
+
+  public async getActiveForAllUsers(): Promise<DetectedSubscriptionDomain[]> {
+    const subscriptions = await prisma.detectedSubscription.findMany({
+      where: {
+        status: { in: ['DETECTED', 'CONFIRMED'] },
+      },
+      orderBy: { userId: 'asc' },
+    });
+    return subscriptions.map(this.mapToDomain);
+  }
+
+  private mapToDomain(db: any): DetectedSubscriptionDomain {
+    return {
+      id: db.id,
+      userId: db.userId,
+      merchantName: db.merchantName,
+      displayName: db.displayName,
+      averageAmount: db.averageAmount,
+      frequency: db.frequency,
+      lastChargeDate: db.lastChargeDate,
+      nextExpectedDate: db.nextExpectedDate,
+      annualCost: db.annualCost,
+      status: db.status,
+      matchingDescriptions: db.matchingDescriptions,
+      scheduledTransactionId: db.scheduledTransactionId ?? undefined,
+      confidence: db.confidence,
+      createdAt: db.createdAt,
+      updatedAt: db.updatedAt,
+    };
+  }
+}
+
+export default new SubscriptionRepository();

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -77,6 +77,7 @@ class UserRepository {
       notifications: {
         createTransaction: user.userNotification?.createTransaction ?? false,
         dailySummary: user.userNotification?.dailySummary ?? false,
+        subscriptionAudit: user.userNotification?.subscriptionAudit ?? false,
       },
       providers: user.userNotificationProviders || [],
     };
@@ -84,7 +85,7 @@ class UserRepository {
 
   public async updateUserSettings(
     userId: string,
-    notifications: { createTransaction: boolean; dailySummary: boolean },
+    notifications: { createTransaction: boolean; dailySummary: boolean; subscriptionAudit: boolean },
     providers: {
       provider: NotificationProvider;
       enabled: boolean;
@@ -96,11 +97,13 @@ class UserRepository {
       update: {
         createTransaction: notifications.createTransaction,
         dailySummary: notifications.dailySummary,
+        subscriptionAudit: notifications.subscriptionAudit,
       },
       create: {
         userId: userId,
         createTransaction: notifications.createTransaction,
         dailySummary: notifications.dailySummary,
+        subscriptionAudit: notifications.subscriptionAudit,
       },
     });
 

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -11,6 +11,7 @@ import trendRouter from './trendRouter';
 import importRouter from './importRouter';
 import chatRouter from './chatRouter';
 import dashboardRouter from './dashboardRouter';
+import subscriptionRouter from './subscriptionRouter';
 import { excelExtractionWebhookController } from '../controllers/excelExtractionWebhookController';
 
 const router = express.Router();
@@ -27,6 +28,7 @@ router.use('/api/trends', trendRouter);
 router.use('/api/imports', importRouter);
 router.use('/api/chat', chatRouter);
 router.use('/api/dashboard', dashboardRouter);
+router.use('/api/subscriptions', subscriptionRouter);
 
 router.get('/', (req, res) => {
   res.send('ok');

--- a/src/routers/subscriptionRouter.ts
+++ b/src/routers/subscriptionRouter.ts
@@ -1,0 +1,71 @@
+import express, { Request } from 'express';
+import subscriptionController from '../controllers/subscriptionController';
+import subscriptionDetectionService from '../services/subscriptionDetectionService';
+import { handleRequest } from '../utils/handleRequest';
+import { validateRequest } from '../middlewares/validation';
+import { ConvertSubscriptionRequest } from '../controllers/requests';
+import { authenticateRequest } from '../middlewares/authMiddleware';
+
+const router = express.Router();
+
+router.get(
+  '/detect',
+  handleRequest(
+    () => subscriptionDetectionService.runDetectionForAllUsers(),
+    200,
+  ),
+);
+
+router.get(
+  '/audit-notify',
+  handleRequest(
+    () => subscriptionDetectionService.sendMonthlyAuditNotifications(),
+    200,
+  ),
+);
+
+router.get(
+  '/',
+  authenticateRequest,
+  handleRequest(
+    (req: Request) =>
+      subscriptionController.list(
+        req.userId ?? '',
+        req.query.status as string | undefined,
+      ),
+    200,
+  ),
+);
+
+router.patch(
+  '/:id/confirm',
+  authenticateRequest,
+  handleRequest(
+    (req: Request) =>
+      subscriptionController.confirm(req.params.id, req.userId ?? ''),
+    200,
+  ),
+);
+
+router.patch(
+  '/:id/dismiss',
+  authenticateRequest,
+  handleRequest(
+    (req: Request) =>
+      subscriptionController.dismiss(req.params.id, req.userId ?? ''),
+    200,
+  ),
+);
+
+router.post(
+  '/:id/convert',
+  validateRequest(ConvertSubscriptionRequest),
+  authenticateRequest,
+  handleRequest(
+    (req: Request) =>
+      subscriptionController.convert(req.params.id, req.userId ?? '', req.body),
+    200,
+  ),
+);
+
+export default router;

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,5 +1,6 @@
 import AIServiceFactory from './ai/aiServiceFactory';
 import dashboardRepository from '../repositories/dashboardRepository';
+import subscriptionDetectionService from './subscriptionDetectionService';
 import {
   DashboardResponse,
   DashboardInsightsResponse,
@@ -28,6 +29,7 @@ class DashboardService {
       topCategoriesCurrent,
       topCategoriesPrevious,
       recentTransactions,
+      subscriptionSnapshot,
     ] = await Promise.all([
       dashboardRepository.getMonthSummary(userId, currentYear, currentMonth),
       dashboardRepository.getMonthSummary(userId, prevYear, prevMonth),
@@ -44,6 +46,7 @@ class DashboardService {
         7,
       ),
       dashboardRepository.getRecentTransactions(userId, 5),
+      subscriptionDetectionService.getDashboardSnapshot(userId),
     ]);
 
     const monthComparison = this.buildMonthComparison(
@@ -56,7 +59,7 @@ class DashboardService {
       currentMonthSummary.totalExpense,
     );
 
-    return { monthComparison, topCategories, recentTransactions };
+    return { monthComparison, topCategories, recentTransactions, subscriptions: subscriptionSnapshot };
   }
 
   public async getInsights(

--- a/src/services/subscriptionDetectionService.ts
+++ b/src/services/subscriptionDetectionService.ts
@@ -1,0 +1,401 @@
+import { SubscriptionFrequency, SubscriptionStatus } from '@prisma/client';
+import { addWeeks, addMonths, addYears } from 'date-fns';
+import prisma from '../prisma/client';
+import subscriptionRepository from '../repositories/subscriptionRepository';
+import scheduledTransactionService from './scheduledTransactionService';
+import TransactionNotifierFactory from './transactionNotification/transactionNotifierFactory';
+import {
+  SubscriptionSummary,
+  DetectedSubscriptionDomain,
+  SubscriptionDashboardSnapshot,
+} from '../types/subscription';
+import {
+  normalizeMerchantName,
+  toDisplayName,
+} from '../utils/merchantNormalizer';
+import logger from '../utils/logger';
+
+interface TransactionGroup {
+  merchantKey: string;
+  descriptions: string[];
+  amounts: number[];
+  dates: Date[];
+}
+
+interface DetectedPattern {
+  merchantKey: string;
+  displayName: string;
+  frequency: SubscriptionFrequency;
+  averageAmount: number;
+  lastChargeDate: Date;
+  nextExpectedDate: Date;
+  annualCost: number;
+  descriptions: string[];
+  confidence: number;
+}
+
+class SubscriptionDetectionService {
+  public async runDetectionForAllUsers(): Promise<void> {
+    const userIds = await subscriptionRepository.getAllUserIds();
+    for (const userId of userIds) {
+      try {
+        await this.detectForUser(userId);
+      } catch (error) {
+        logger.error(`Subscription detection failed for user ${userId}`, error);
+      }
+    }
+  }
+
+  public async getSubscriptions(
+    userId: string,
+    status?: SubscriptionStatus,
+  ): Promise<SubscriptionSummary> {
+    const subscriptions = await subscriptionRepository.getByUserId(
+      userId,
+      status,
+    );
+
+    let totalMonthlyEstimate = 0;
+    let totalAnnualEstimate = 0;
+    let activeCount = 0;
+    let detectedCount = 0;
+
+    for (const s of subscriptions) {
+      if (s.status === 'CONFIRMED') {
+        activeCount++;
+        totalMonthlyEstimate += this.toMonthlyAmount(s.averageAmount, s.frequency);
+        totalAnnualEstimate += s.annualCost;
+      } else if (s.status === 'DETECTED') {
+        detectedCount++;
+        totalMonthlyEstimate += this.toMonthlyAmount(s.averageAmount, s.frequency);
+        totalAnnualEstimate += s.annualCost;
+      }
+    }
+
+    return {
+      totalMonthlyEstimate,
+      totalAnnualEstimate,
+      activeCount,
+      detectedCount,
+      subscriptions,
+    };
+  }
+
+  public async confirmSubscription(
+    id: string,
+    userId: string,
+  ): Promise<DetectedSubscriptionDomain> {
+    return subscriptionRepository.updateStatus(id, userId, 'CONFIRMED');
+  }
+
+  public async dismissSubscription(
+    id: string,
+    userId: string,
+  ): Promise<DetectedSubscriptionDomain> {
+    return subscriptionRepository.updateStatus(id, userId, 'DISMISSED');
+  }
+
+  public async convertToScheduledTransaction(
+    id: string,
+    userId: string,
+    categoryId: string,
+  ): Promise<DetectedSubscriptionDomain> {
+    const subscription = await subscriptionRepository.getById(id, userId);
+    if (!subscription) {
+      throw new Error('Subscription not found');
+    }
+
+    const scheduledId =
+      await scheduledTransactionService.createScheduledTransaction({
+        description: subscription.displayName,
+        value: subscription.averageAmount,
+        type: 'EXPENSE',
+        categoryId,
+        scheduleType: subscription.frequency,
+        userId,
+        dayOfMonth: subscription.frequency === 'MONTHLY' ? subscription.lastChargeDate.getDate() : undefined,
+        dayOfWeek: subscription.frequency === 'WEEKLY' ? subscription.lastChargeDate.getDay() : undefined,
+      });
+
+    return subscriptionRepository.linkScheduledTransaction(
+      id,
+      userId,
+      scheduledId,
+    );
+  }
+
+  public async getDashboardSnapshot(
+    userId: string,
+  ): Promise<SubscriptionDashboardSnapshot> {
+    return subscriptionRepository.getSnapshotByUserId(userId);
+  }
+
+  public async sendMonthlyAuditNotifications(): Promise<void> {
+    const allActive = await subscriptionRepository.getActiveForAllUsers();
+    const byUser = new Map<string, DetectedSubscriptionDomain[]>();
+
+    for (const sub of allActive) {
+      const existing = byUser.get(sub.userId) || [];
+      existing.push(sub);
+      byUser.set(sub.userId, existing);
+    }
+
+    const userIds = Array.from(byUser.keys());
+    const allPrefs = await prisma.userNotificationPreference.findMany({
+      where: { userId: { in: userIds }, subscriptionAudit: true },
+    });
+    const enabledUserIds = new Set(allPrefs.map((p) => p.userId));
+
+    const notifier = TransactionNotifierFactory.getNotifier();
+
+    for (const [userId, subs] of byUser) {
+      try {
+        if (!enabledUserIds.has(userId)) continue;
+
+        const confirmed = subs.filter((s) => s.status === 'CONFIRMED');
+        const detected = subs.filter((s) => s.status === 'DETECTED');
+
+        if (confirmed.length === 0 && detected.length === 0) continue;
+
+        const now = new Date();
+        const monthName = now.toLocaleString('en-US', { month: 'long' });
+        const year = now.getFullYear();
+
+        const lines = [`Subscription Audit — ${monthName} ${year}`, ''];
+
+        if (confirmed.length > 0) {
+          lines.push('Active Subscriptions:');
+          let totalMonthly = 0;
+          let totalAnnual = 0;
+          for (const sub of confirmed) {
+            const monthly = this.toMonthlyAmount(
+              sub.averageAmount,
+              sub.frequency,
+            );
+            totalMonthly += monthly;
+            totalAnnual += sub.annualCost;
+            lines.push(
+              `- ${sub.displayName}: $${monthly.toFixed(2)}/mo ($${sub.annualCost.toFixed(2)}/yr)`,
+            );
+          }
+          lines.push('');
+          lines.push(
+            `Total: $${totalMonthly.toFixed(2)}/month | $${totalAnnual.toFixed(2)}/year`,
+          );
+        }
+
+        if (detected.length > 0) {
+          lines.push(
+            `${detected.length} new subscription${detected.length > 1 ? 's' : ''} detected — review in app`,
+          );
+        }
+
+        await notifier.sendDailySummary(lines.join('\n'), userId);
+      } catch (error) {
+        logger.error(
+          `Failed to send subscription audit for user ${userId}`,
+          error,
+        );
+      }
+    }
+  }
+
+  private async detectForUser(userId: string): Promise<void> {
+    const twelveMonthsAgo = new Date();
+    twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12);
+
+    const transactions = await prisma.transaction.findMany({
+      where: {
+        userId,
+        type: 'EXPENSE',
+        status: 'APPROVED',
+        date: { gte: twelveMonthsAgo },
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const groups = this.groupByMerchant(transactions);
+    const dismissed = await subscriptionRepository.getDismissedMerchants(userId);
+    const dismissedSet = new Set(
+      dismissed.map((d) => `${d.merchantName}:${d.frequency}`),
+    );
+
+    for (const group of groups) {
+      if (group.dates.length < 3) continue;
+
+      const pattern = this.analyzePattern(group);
+      if (!pattern) continue;
+
+      if (dismissedSet.has(`${pattern.merchantKey}:${pattern.frequency}`)) {
+        continue;
+      }
+
+      await subscriptionRepository.upsert({
+        userId,
+        merchantName: pattern.merchantKey,
+        displayName: pattern.displayName,
+        averageAmount: pattern.averageAmount,
+        frequency: pattern.frequency,
+        lastChargeDate: pattern.lastChargeDate,
+        nextExpectedDate: pattern.nextExpectedDate,
+        annualCost: pattern.annualCost,
+        matchingDescriptions: pattern.descriptions,
+        confidence: pattern.confidence,
+      });
+    }
+  }
+
+  private groupByMerchant(
+    transactions: { description: string; value: number; date: Date }[],
+  ): TransactionGroup[] {
+    const groups = new Map<string, TransactionGroup>();
+
+    for (const tx of transactions) {
+      const key = normalizeMerchantName(tx.description);
+      if (!key) continue;
+
+      const existing = groups.get(key);
+      if (existing) {
+        existing.descriptions.push(tx.description);
+        existing.amounts.push(tx.value);
+        existing.dates.push(tx.date);
+      } else {
+        groups.set(key, {
+          merchantKey: key,
+          descriptions: [tx.description],
+          amounts: [tx.value],
+          dates: [tx.date],
+        });
+      }
+    }
+
+    return Array.from(groups.values());
+  }
+
+  private analyzePattern(group: TransactionGroup): DetectedPattern | null {
+    const sortedDates = [...group.dates].sort(
+      (a, b) => a.getTime() - b.getTime(),
+    );
+
+    const intervals: number[] = [];
+    for (let i = 1; i < sortedDates.length; i++) {
+      const diffDays =
+        (sortedDates[i].getTime() - sortedDates[i - 1].getTime()) /
+        (1000 * 60 * 60 * 24);
+      intervals.push(diffDays);
+    }
+
+    if (intervals.length === 0) return null;
+
+    const sorted = [...intervals].sort((a, b) => a - b);
+    const median =
+      sorted.length % 2 === 0
+        ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+        : sorted[Math.floor(sorted.length / 2)];
+
+    const variance =
+      intervals.reduce((sum, v) => sum + Math.pow(v - median, 2), 0) /
+      intervals.length;
+    const stddev = Math.sqrt(variance);
+
+    const frequency = this.classifyFrequency(median);
+    if (!frequency) return null;
+
+    if (median > 0 && stddev / median > 0.3) return null;
+
+    const confidence = Math.max(0, Math.min(1, 1 - stddev / median));
+    const averageAmount =
+      group.amounts.reduce((sum, a) => sum + a, 0) / group.amounts.length;
+    const lastChargeDate = sortedDates[sortedDates.length - 1];
+    const nextExpectedDate = this.calculateNextExpectedDate(
+      lastChargeDate,
+      frequency,
+    );
+    const annualCost = this.calculateAnnualCost(averageAmount, frequency);
+    const displayName = this.pickDisplayName(group.descriptions);
+
+    return {
+      merchantKey: group.merchantKey,
+      displayName,
+      frequency,
+      averageAmount: Math.round(averageAmount * 100) / 100,
+      lastChargeDate,
+      nextExpectedDate,
+      annualCost: Math.round(annualCost * 100) / 100,
+      descriptions: [...new Set(group.descriptions)],
+      confidence: Math.round(confidence * 100) / 100,
+    };
+  }
+
+  private classifyFrequency(
+    medianDays: number,
+  ): SubscriptionFrequency | null {
+    if (medianDays >= 5 && medianDays <= 9) return 'WEEKLY';
+    if (medianDays >= 25 && medianDays <= 35) return 'MONTHLY';
+    if (medianDays >= 340 && medianDays <= 395) return 'YEARLY';
+    return null;
+  }
+
+  private calculateNextExpectedDate(
+    lastDate: Date,
+    frequency: SubscriptionFrequency,
+  ): Date {
+    switch (frequency) {
+      case 'WEEKLY':
+        return addWeeks(lastDate, 1);
+      case 'MONTHLY':
+        return addMonths(lastDate, 1);
+      case 'YEARLY':
+        return addYears(lastDate, 1);
+    }
+  }
+
+  private calculateAnnualCost(
+    amount: number,
+    frequency: SubscriptionFrequency,
+  ): number {
+    switch (frequency) {
+      case 'WEEKLY':
+        return amount * 52;
+      case 'MONTHLY':
+        return amount * 12;
+      case 'YEARLY':
+        return amount;
+    }
+  }
+
+  private toMonthlyAmount(
+    amount: number,
+    frequency: SubscriptionFrequency,
+  ): number {
+    switch (frequency) {
+      case 'WEEKLY':
+        return (amount * 52) / 12;
+      case 'MONTHLY':
+        return amount;
+      case 'YEARLY':
+        return amount / 12;
+    }
+  }
+
+  private pickDisplayName(descriptions: string[]): string {
+    const descriptionCounts = new Map<string, number>();
+    for (const desc of descriptions) {
+      const trimmed = desc.trim();
+      descriptionCounts.set(trimmed, (descriptionCounts.get(trimmed) || 0) + 1);
+    }
+
+    let mostCommon = descriptions[0];
+    let maxCount = 0;
+    for (const [desc, count] of descriptionCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        mostCommon = desc;
+      }
+    }
+
+    return toDisplayName(mostCommon);
+  }
+}
+
+export default new SubscriptionDetectionService();

--- a/src/services/userSettingsService.ts
+++ b/src/services/userSettingsService.ts
@@ -23,6 +23,7 @@ class UserSettingsService {
       notifications: {
         createTransaction: userSettings.notifications.createTransaction,
         dailySummary: userSettings.notifications.dailySummary,
+        subscriptionAudit: userSettings.notifications.subscriptionAudit,
       },
       provider: {
         enabled: userSettings.providers[0]?.enabled ?? false,
@@ -36,7 +37,7 @@ class UserSettingsService {
     userId: string,
     settings: {
       info: { email: string };
-      notifications: { createTransaction: boolean; dailySummary: boolean };
+      notifications: { createTransaction: boolean; dailySummary: boolean; subscriptionAudit: boolean };
       provider: {
         enabled: boolean;
         chatId: string | null;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,7 +1,15 @@
+export interface SubscriptionSnapshot {
+  activeCount: number;
+  totalMonthlyEstimate: number;
+  totalAnnualEstimate: number;
+  detectedCount: number;
+}
+
 export interface DashboardResponse {
   monthComparison: MonthComparison;
   topCategories: TopCategory[];
   recentTransactions: RecentTransaction[];
+  subscriptions?: SubscriptionSnapshot;
 }
 
 export interface DashboardInsightsResponse {

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -1,0 +1,34 @@
+import { SubscriptionFrequency, SubscriptionStatus } from '@prisma/client';
+
+export interface DetectedSubscriptionDomain {
+  id: string;
+  userId: string;
+  merchantName: string;
+  displayName: string;
+  averageAmount: number;
+  frequency: SubscriptionFrequency;
+  lastChargeDate: Date;
+  nextExpectedDate: Date;
+  annualCost: number;
+  status: SubscriptionStatus;
+  matchingDescriptions: string[];
+  scheduledTransactionId?: string;
+  confidence: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SubscriptionSummary {
+  totalMonthlyEstimate: number;
+  totalAnnualEstimate: number;
+  activeCount: number;
+  detectedCount: number;
+  subscriptions: DetectedSubscriptionDomain[];
+}
+
+export interface SubscriptionDashboardSnapshot {
+  activeCount: number;
+  totalMonthlyEstimate: number;
+  totalAnnualEstimate: number;
+  detectedCount: number;
+}

--- a/src/utils/merchantNormalizer.ts
+++ b/src/utils/merchantNormalizer.ts
@@ -1,0 +1,23 @@
+const SUFFIX_PATTERN = /\b(inc|ltd|llc|com|co|corp|corporation|limited)\b/gi;
+const TRAILING_DIGITS = /\d+$/;
+const SPECIAL_CHARS = /[*#\-_.]/g;
+const MULTIPLE_SPACES = /\s{2,}/g;
+
+export function normalizeMerchantName(description: string): string {
+  return description
+    .toLowerCase()
+    .trim()
+    .replace(SUFFIX_PATTERN, '')
+    .replace(TRAILING_DIGITS, '')
+    .replace(SPECIAL_CHARS, ' ')
+    .replace(MULTIPLE_SPACES, ' ')
+    .trim();
+}
+
+export function toDisplayName(description: string): string {
+  return description
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- **Prisma schema**: `DetectedSubscription` model with `SubscriptionStatus`/`SubscriptionFrequency` enums, compound unique on `[userId, merchantName, frequency]`, `subscriptionAudit` notification preference on `UserNotificationPreference`
- **Detection algorithm**: Normalizes merchant names, groups transactions, classifies frequency (weekly/monthly/yearly) using median interval + stddev, computes confidence scores. Skips dismissed merchants, upserts to avoid duplicates
- **Full API layer**: Repository → Service → Controller → Router with 6 endpoints (`GET /detect`, `GET /audit-notify`, `GET /`, `PATCH /:id/confirm`, `PATCH /:id/dismiss`, `POST /:id/convert`)
- **Dashboard integration**: Subscription snapshot (active count, monthly/annual estimates, detected count) piggybacked on existing dashboard response via `Promise.all`
- **Notification**: Monthly subscription audit via Telegram using existing notifier infrastructure, gated by `subscriptionAudit` user preference
- **Settings**: `subscriptionAudit` boolean threaded through repository → service → controller → request DTO

## Test plan
- [ ] Run `GET /api/subscriptions/detect` with seeded transactions containing known recurring merchants — verify subscriptions created with correct frequency, amount, confidence
- [ ] Authenticate and call `GET /api/subscriptions` — verify summary totals and subscription list
- [ ] Call `PATCH /:id/confirm` and `PATCH /:id/dismiss` — verify status changes persist
- [ ] Call `POST /:id/convert` with valid categoryId — verify scheduled transaction created and linked
- [ ] Call `GET /api/subscriptions/audit-notify` — verify Telegram message for users with `subscriptionAudit` enabled
- [ ] Verify `GET /api/dashboard` includes `subscriptions` snapshot in response
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)