### PR TITLE
Fix chat assistant numerical accuracy

### DIFF
--- a/dist/services/chatAggregationService.js
+++ b/dist/services/chatAggregationService.js
@@ -1,0 +1,146 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class ChatAggregationService {
+    aggregate(transactions, aggregationType) {
+        switch (aggregationType) {
+            case 'total':
+                return this.computeTotal(transactions);
+            case 'average':
+                return this.computeAverage(transactions);
+            case 'count':
+                return this.computeCount(transactions);
+            case 'breakdown_by_category':
+                return this.computeCategoryBreakdown(transactions);
+            case 'breakdown_by_month':
+                return this.computeMonthlyBreakdown(transactions);
+            case 'min_max':
+                return this.computeMinMax(transactions);
+            case 'list':
+                return this.formatList(transactions);
+        }
+    }
+    computeTotal(transactions) {
+        const income = this.sumByType(transactions, 'INCOME');
+        const expense = this.sumByType(transactions, 'EXPENSE');
+        const net = income - expense;
+        const lines = [
+            `Total Income: ${this.formatCurrency(income)}`,
+            `Total Expenses: ${this.formatCurrency(expense)}`,
+            `Net: ${this.formatCurrency(net)}`,
+        ];
+        return {
+            summary: lines.join('\n'),
+            data: { income, expense, net },
+            transactionCount: transactions.length,
+        };
+    }
+    computeAverage(transactions) {
+        if (transactions.length === 0) {
+            return {
+                summary: 'No transactions found to calculate an average.',
+                data: { average: 0 },
+                transactionCount: 0,
+            };
+        }
+        const total = transactions.reduce((sum, t) => sum + t.value, 0);
+        const average = Math.round((total / transactions.length) * 100) / 100;
+        return {
+            summary: `Average transaction value: ${this.formatCurrency(average)} (across ${transactions.length} transactions, total: ${this.formatCurrency(total)})`,
+            data: { average, total, count: transactions.length },
+            transactionCount: transactions.length,
+        };
+    }
+    computeCount(transactions) {
+        const incomeCount = transactions.filter((t) => t.type === 'INCOME').length;
+        const expenseCount = transactions.filter((t) => t.type === 'EXPENSE').length;
+        return {
+            summary: `Total transactions: ${transactions.length} (${incomeCount} income, ${expenseCount} expenses)`,
+            data: { total: transactions.length, incomeCount, expenseCount },
+            transactionCount: transactions.length,
+        };
+    }
+    computeCategoryBreakdown(transactions) {
+        const byCategory = new Map();
+        for (const t of transactions) {
+            const name = t.category.name;
+            byCategory.set(name, (byCategory.get(name) || 0) + t.value);
+        }
+        const sorted = [...byCategory.entries()].sort(([, a], [, b]) => b - a);
+        const lines = sorted.map(([name, amount]) => `  ${name}: ${this.formatCurrency(amount)}`);
+        const total = sorted.reduce((sum, [, amount]) => sum + amount, 0);
+        return {
+            summary: `Spending by category:\n${lines.join('\n')}\n\nTotal: ${this.formatCurrency(total)}`,
+            data: Object.fromEntries(sorted),
+            transactionCount: transactions.length,
+        };
+    }
+    computeMonthlyBreakdown(transactions) {
+        const byMonth = new Map();
+        for (const t of transactions) {
+            const month = new Date(t.date).toISOString().slice(0, 7);
+            byMonth.set(month, (byMonth.get(month) || 0) + t.value);
+        }
+        const sorted = [...byMonth.entries()].sort(([a], [b]) => a.localeCompare(b));
+        const lines = sorted.map(([month, amount]) => `  ${month}: ${this.formatCurrency(amount)}`);
+        return {
+            summary: `Monthly breakdown:\n${lines.join('\n')}`,
+            data: Object.fromEntries(sorted),
+            transactionCount: transactions.length,
+        };
+    }
+    computeMinMax(transactions) {
+        if (transactions.length === 0) {
+            return {
+                summary: 'No transactions found.',
+                data: {},
+                transactionCount: 0,
+            };
+        }
+        const sorted = [...transactions].sort((a, b) => b.value - a.value);
+        const highest = sorted[0];
+        const lowest = sorted[sorted.length - 1];
+        return {
+            summary: [
+                `Highest: ${this.formatCurrency(highest.value)} — "${highest.description}" (${highest.category.name}, ${this.formatDate(highest.date)})`,
+                `Lowest: ${this.formatCurrency(lowest.value)} — "${lowest.description}" (${lowest.category.name}, ${this.formatDate(lowest.date)})`,
+            ].join('\n'),
+            data: {
+                highestValue: highest.value,
+                highestDescription: highest.description,
+                lowestValue: lowest.value,
+                lowestDescription: lowest.description,
+            },
+            transactionCount: transactions.length,
+        };
+    }
+    formatList(transactions) {
+        const top = transactions.slice(0, 10);
+        const total = transactions.reduce((sum, t) => sum + t.value, 0);
+        const lines = top.map((t) => `  - ${this.formatDate(t.date)} | ${t.description} | ${this.formatCurrency(t.value)} | ${t.category.name} (${t.type})`);
+        const summaryParts = [
+            `Showing ${top.length} of ${transactions.length} transactions:`,
+            ...lines,
+        ];
+        if (transactions.length > 10) {
+            summaryParts.push(`  ... and ${transactions.length - 10} more`);
+        }
+        summaryParts.push(`\nTotal value: ${this.formatCurrency(total)}`);
+        return {
+            summary: summaryParts.join('\n'),
+            data: { shown: top.length, total: transactions.length, totalValue: total },
+            transactionCount: transactions.length,
+        };
+    }
+    sumByType(transactions, type) {
+        return transactions
+            .filter((t) => t.type === type)
+            .reduce((sum, t) => sum + t.value, 0);
+    }
+    formatCurrency(amount) {
+        return `₪${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    }
+    formatDate(date) {
+        return new Date(date).toISOString().split('T')[0];
+    }
+}
+exports.default = new ChatAggregationService();

--- a/dist/services/chatService.js
+++ b/dist/services/chatService.js
@@ -5,56 +5,114 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const aiServiceFactory_1 = __importDefault(require("../services/ai/aiServiceFactory"));
 const transactionRepository_1 = __importDefault(require("../repositories/transactionRepository"));
+const categoryRepository_1 = __importDefault(require("../repositories/categoryRepository"));
+const chatAggregationService_1 = __importDefault(require("./chatAggregationService"));
 class ChatService {
     constructor() {
         this.aiProvider = aiServiceFactory_1.default.getAIService();
         this.transactionRepository = transactionRepository_1.default;
+        this.categoryRepository = categoryRepository_1.default;
     }
     async getChatResponse(messages, userId) {
         var _a;
         const currentDate = new Date().toISOString().split('T')[0];
-        const conversation = messages.map(m => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.text}`).join('\n');
-        const lastUserMessage = ((_a = [...messages].reverse().find(m => m.sender === 'user')) === null || _a === void 0 ? void 0 : _a.text) || '';
-        const prompt = `
-      You are a financial assistant chatbot. Your task is to understand the user's request about their transactions and respond in a helpful, conversational way.
-      The current date is ${currentDate}. Please use this as a reference for any relative date queries (e.g., 'last week', 'yesterday').
-      Here is the conversation so far:\n${conversation}\n
+        const conversation = messages
+            .map((m) => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.text}`)
+            .join('\n');
+        const lastUserMessage = ((_a = [...messages].reverse().find((m) => m.sender === 'user')) === null || _a === void 0 ? void 0 : _a.text) || '';
+        const intentPrompt = `
+      You are a financial assistant chatbot. Your task is to understand the user's request about their transactions.
+      The current date is ${currentDate}. Use this as a reference for relative date queries (e.g., 'last week', 'yesterday').
+
+      Conversation so far:\n${conversation}\n
+
       Analyze the user's latest message: "${lastUserMessage}"
 
-      Based on the conversation, determine the user's intent and extract relevant parameters. The primary intents are 'list_transactions' and 'get_transaction_summary'.
+      Determine the user's intent and extract relevant parameters. Respond with a JSON object.
 
-      Extract the following parameters if present:
-      - category (e.g., 'groceries', 'rent')
-      - startDate (in YYYY-MM-DD format)
-      - endDate (in YYYY-MM-DD format)
+      Intents:
+      - "list_transactions" — user wants to see specific transactions
+      - "get_transaction_summary" — user wants totals, averages, or breakdowns
+      - "compare_periods" — user wants to compare spending across time periods
+      - "general_question" — general financial question not about their data
 
-      Your response should be a JSON object with the intent and parameters. For example:
-      { "intent": "list_transactions", "parameters": { "category": "restaurants", "startDate": "2025-07-01", "endDate": "2025-07-04" } }
+      Parameters to extract (if present):
+      - category: the category name (e.g., "groceries", "restaurants")
+      - startDate: in YYYY-MM-DD format
+      - endDate: in YYYY-MM-DD format
+      - transactionType: "INCOME" or "EXPENSE"
+
+      Aggregation types — pick the one that best matches the user's question:
+      - "total" — sum of transactions (e.g., "How much did I spend on X?")
+      - "average" — average transaction value (e.g., "What's my average grocery expense?")
+      - "count" — count of transactions (e.g., "How many transactions this month?")
+      - "breakdown_by_category" — group by category (e.g., "Show spending by category")
+      - "breakdown_by_month" — group by month (e.g., "Monthly spending trend")
+      - "min_max" — highest and lowest (e.g., "What was my biggest expense?")
+      - "list" — show individual transactions (e.g., "List my restaurant transactions")
+
+      Examples:
+      - "How much did I spend last month?" → { "intent": "get_transaction_summary", "parameters": { "startDate": "...", "endDate": "...", "transactionType": "EXPENSE" }, "aggregation": "total" }
+      - "What's my average grocery expense?" → { "intent": "get_transaction_summary", "parameters": { "category": "groceries", "transactionType": "EXPENSE" }, "aggregation": "average" }
+      - "Show me spending by category" → { "intent": "get_transaction_summary", "parameters": { "transactionType": "EXPENSE" }, "aggregation": "breakdown_by_category" }
+      - "List my restaurant transactions" → { "intent": "list_transactions", "parameters": { "category": "restaurants" }, "aggregation": "list" }
+
+      Respond ONLY with valid JSON, no markdown fences.
     `;
         try {
-            const result = await this.aiProvider.generateContent(prompt);
-            const parsedResult = JSON.parse(result.replace(/```json/g, '').replace(/```/g, ''));
+            const result = await this.aiProvider.generateContent(intentPrompt);
+            const parsedResult = JSON.parse(result.replace(/```json/g, '').replace(/```/g, '').trim());
             const { intent, parameters } = parsedResult;
-            let transactions;
-            if (intent === 'list_transactions' || intent === 'get_transaction_summary') {
-                transactions = await this.transactionRepository.getTransactions(Object.assign({ userId, page: 1, perPage: 100 }, parameters));
-            }
-            else {
+            if (intent !== 'list_transactions' &&
+                intent !== 'get_transaction_summary' &&
+                intent !== 'compare_periods') {
                 return "I'm sorry, I can only help with questions about your transactions. Please try asking something like, 'How much did I spend on groceries last week?'";
             }
-            const finalPrompt = `
-        You are a friendly financial assistant. The current date is ${currentDate}. The user asked: "${lastUserMessage}"
-        You have retrieved the following transaction data: ${JSON.stringify(transactions, null, 2)}
-        
-        Based on this data, provide a clear and concise answer to the user's question.
+            const categoryId = await this.resolveCategoryId(parameters.category);
+            const aggregationType = this.resolveAggregationType(parsedResult);
+            const isListQuery = aggregationType === 'list';
+            const transactions = await this.transactionRepository.getTransactions(Object.assign(Object.assign(Object.assign(Object.assign({ userId, page: 1, perPage: isListQuery ? 100 : 10000 }, (parameters.startDate
+                ? { startDate: new Date(parameters.startDate) }
+                : {})), (parameters.endDate
+                ? { endDate: new Date(parameters.endDate) }
+                : {})), (parameters.transactionType
+                ? { transactionType: parameters.transactionType }
+                : {})), (categoryId ? { categoryId } : {})));
+            const aggregationResult = chatAggregationService_1.default.aggregate(transactions, aggregationType);
+            const responsePrompt = `
+        You are a friendly financial assistant. The user asked: "${lastUserMessage}"
+
+        Here are the EXACT pre-computed results. Do NOT recalculate these numbers — use them as-is:
+        ${aggregationResult.summary}
+
+        ${aggregationResult.transactionCount} transactions were analyzed.
+
+        Present this information conversationally to the user. Use the exact numbers provided. Keep currency in ₪ (Israeli Shekel).
       `;
-            const finalResult = await this.aiProvider.generateContent(finalPrompt);
-            return finalResult;
+            return await this.aiProvider.generateContent(responsePrompt);
         }
         catch (error) {
             console.error('Error in ChatService:', error);
             return "I'm sorry, something went wrong while I was trying to understand that. Please try again.";
         }
+    }
+    async resolveCategoryId(categoryName) {
+        if (!categoryName)
+            return undefined;
+        const categories = await this.categoryRepository.getAllCategories();
+        const lowerName = categoryName.toLowerCase();
+        const exact = categories.find((c) => c.name.toLowerCase() === lowerName);
+        if (exact)
+            return exact.id;
+        const partial = categories.find((c) => c.name.toLowerCase().includes(lowerName));
+        return partial === null || partial === void 0 ? void 0 : partial.id;
+    }
+    resolveAggregationType(parsed) {
+        if (parsed.aggregation)
+            return parsed.aggregation;
+        if (parsed.intent === 'list_transactions')
+            return 'list';
+        return 'total';
     }
 }
 exports.default = new ChatService();

--- a/dist/types/chat.js
+++ b/dist/types/chat.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "commonjs",
   "scripts": {
-    "build": "rimraf dist && npx prisma generate && tsc",
+    "build": "rm -rf dist && npx prisma generate && tsc",
     "start": "npx prisma migrate deploy && node dist/index.js",
     "dev": "npx prisma migrate deploy && ts-node src/index.ts",
     "watch": "npx prisma migrate deploy && nodemon --exec ts-node src/index.ts",
@@ -46,8 +46,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^3.3.3",
     "prisma": "^6.9.0",
-    "rimraf": "^6.0.1",
-    "ts-node": "^10.9.2",
+"ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.7.0"
   },

--- a/src/services/chatAggregationService.ts
+++ b/src/services/chatAggregationService.ts
@@ -1,0 +1,195 @@
+import { Transaction } from '../types/transaction';
+import { AggregationType, AggregationResult } from '../types/chat';
+
+class ChatAggregationService {
+  public aggregate(
+    transactions: Transaction[],
+    aggregationType: AggregationType,
+  ): AggregationResult {
+    switch (aggregationType) {
+      case 'total':
+        return this.computeTotal(transactions);
+      case 'average':
+        return this.computeAverage(transactions);
+      case 'count':
+        return this.computeCount(transactions);
+      case 'breakdown_by_category':
+        return this.computeCategoryBreakdown(transactions);
+      case 'breakdown_by_month':
+        return this.computeMonthlyBreakdown(transactions);
+      case 'min_max':
+        return this.computeMinMax(transactions);
+      case 'list':
+        return this.formatList(transactions);
+    }
+  }
+
+  private computeTotal(transactions: Transaction[]): AggregationResult {
+    const income = this.sumByType(transactions, 'INCOME');
+    const expense = this.sumByType(transactions, 'EXPENSE');
+    const net = income - expense;
+
+    const lines = [
+      `Total Income: ${this.formatCurrency(income)}`,
+      `Total Expenses: ${this.formatCurrency(expense)}`,
+      `Net: ${this.formatCurrency(net)}`,
+    ];
+
+    return {
+      summary: lines.join('\n'),
+      data: { income, expense, net },
+      transactionCount: transactions.length,
+    };
+  }
+
+  private computeAverage(transactions: Transaction[]): AggregationResult {
+    if (transactions.length === 0) {
+      return {
+        summary: 'No transactions found to calculate an average.',
+        data: { average: 0 },
+        transactionCount: 0,
+      };
+    }
+
+    const total = transactions.reduce((sum, t) => sum + t.value, 0);
+    const average = Math.round((total / transactions.length) * 100) / 100;
+
+    return {
+      summary: `Average transaction value: ${this.formatCurrency(average)} (across ${transactions.length} transactions, total: ${this.formatCurrency(total)})`,
+      data: { average, total, count: transactions.length },
+      transactionCount: transactions.length,
+    };
+  }
+
+  private computeCount(transactions: Transaction[]): AggregationResult {
+    const incomeCount = transactions.filter(
+      (t) => t.type === 'INCOME',
+    ).length;
+    const expenseCount = transactions.filter(
+      (t) => t.type === 'EXPENSE',
+    ).length;
+
+    return {
+      summary: `Total transactions: ${transactions.length} (${incomeCount} income, ${expenseCount} expenses)`,
+      data: { total: transactions.length, incomeCount, expenseCount },
+      transactionCount: transactions.length,
+    };
+  }
+
+  private computeCategoryBreakdown(
+    transactions: Transaction[],
+  ): AggregationResult {
+    const byCategory = new Map<string, number>();
+    for (const t of transactions) {
+      const name = t.category.name;
+      byCategory.set(name, (byCategory.get(name) || 0) + t.value);
+    }
+
+    const sorted = [...byCategory.entries()].sort(([, a], [, b]) => b - a);
+    const lines = sorted.map(
+      ([name, amount]) => `  ${name}: ${this.formatCurrency(amount)}`,
+    );
+    const total = sorted.reduce((sum, [, amount]) => sum + amount, 0);
+
+    return {
+      summary: `Spending by category:\n${lines.join('\n')}\n\nTotal: ${this.formatCurrency(total)}`,
+      data: Object.fromEntries(sorted),
+      transactionCount: transactions.length,
+    };
+  }
+
+  private computeMonthlyBreakdown(
+    transactions: Transaction[],
+  ): AggregationResult {
+    const byMonth = new Map<string, number>();
+    for (const t of transactions) {
+      const month = new Date(t.date).toISOString().slice(0, 7);
+      byMonth.set(month, (byMonth.get(month) || 0) + t.value);
+    }
+
+    const sorted = [...byMonth.entries()].sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    const lines = sorted.map(
+      ([month, amount]) => `  ${month}: ${this.formatCurrency(amount)}`,
+    );
+
+    return {
+      summary: `Monthly breakdown:\n${lines.join('\n')}`,
+      data: Object.fromEntries(sorted),
+      transactionCount: transactions.length,
+    };
+  }
+
+  private computeMinMax(transactions: Transaction[]): AggregationResult {
+    if (transactions.length === 0) {
+      return {
+        summary: 'No transactions found.',
+        data: {},
+        transactionCount: 0,
+      };
+    }
+
+    const sorted = [...transactions].sort((a, b) => b.value - a.value);
+    const highest = sorted[0];
+    const lowest = sorted[sorted.length - 1];
+
+    return {
+      summary: [
+        `Highest: ${this.formatCurrency(highest.value)} — "${highest.description}" (${highest.category.name}, ${this.formatDate(highest.date)})`,
+        `Lowest: ${this.formatCurrency(lowest.value)} — "${lowest.description}" (${lowest.category.name}, ${this.formatDate(lowest.date)})`,
+      ].join('\n'),
+      data: {
+        highestValue: highest.value,
+        highestDescription: highest.description,
+        lowestValue: lowest.value,
+        lowestDescription: lowest.description,
+      },
+      transactionCount: transactions.length,
+    };
+  }
+
+  private formatList(transactions: Transaction[]): AggregationResult {
+    const top = transactions.slice(0, 10);
+    const total = transactions.reduce((sum, t) => sum + t.value, 0);
+
+    const lines = top.map(
+      (t) =>
+        `  - ${this.formatDate(t.date)} | ${t.description} | ${this.formatCurrency(t.value)} | ${t.category.name} (${t.type})`,
+    );
+
+    const summaryParts = [
+      `Showing ${top.length} of ${transactions.length} transactions:`,
+      ...lines,
+    ];
+    if (transactions.length > 10) {
+      summaryParts.push(`  ... and ${transactions.length - 10} more`);
+    }
+    summaryParts.push(`\nTotal value: ${this.formatCurrency(total)}`);
+
+    return {
+      summary: summaryParts.join('\n'),
+      data: { shown: top.length, total: transactions.length, totalValue: total },
+      transactionCount: transactions.length,
+    };
+  }
+
+  private sumByType(
+    transactions: Transaction[],
+    type: 'INCOME' | 'EXPENSE',
+  ): number {
+    return transactions
+      .filter((t) => t.type === type)
+      .reduce((sum, t) => sum + t.value, 0);
+  }
+
+  private formatCurrency(amount: number): string {
+    return `₪${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+
+  private formatDate(date: Date): string {
+    return new Date(date).toISOString().split('T')[0];
+  }
+}
+
+export default new ChatAggregationService();

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,70 +1,155 @@
 import AIServiceFactory from '../services/ai/aiServiceFactory';
 import transactionRepository from '../repositories/transactionRepository';
+import categoryRepository from '../repositories/categoryRepository';
+import chatAggregationService from './chatAggregationService';
 import { Transaction } from '../types/transaction';
 import { AIProvider } from '../services/ai/aiProvider';
+import { ChatIntent, AggregationType } from '../types/chat';
 
 class ChatService {
   private aiProvider: AIProvider;
   private transactionRepository: typeof transactionRepository;
+  private categoryRepository: typeof categoryRepository;
 
   constructor() {
     this.aiProvider = AIServiceFactory.getAIService();
     this.transactionRepository = transactionRepository;
+    this.categoryRepository = categoryRepository;
   }
 
-  public async getChatResponse(messages: { sender: string; text: string }[], userId: string): Promise<string> {
+  public async getChatResponse(
+    messages: { sender: string; text: string }[],
+    userId: string,
+  ): Promise<string> {
     const currentDate = new Date().toISOString().split('T')[0];
-    const conversation = messages.map(m => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.text}`).join('\n');
-    const lastUserMessage = [...messages].reverse().find(m => m.sender === 'user')?.text || '';
+    const conversation = messages
+      .map((m) => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.text}`)
+      .join('\n');
+    const lastUserMessage =
+      [...messages].reverse().find((m) => m.sender === 'user')?.text || '';
 
-    const prompt = `
-      You are a financial assistant chatbot. Your task is to understand the user's request about their transactions and respond in a helpful, conversational way.
-      The current date is ${currentDate}. Please use this as a reference for any relative date queries (e.g., 'last week', 'yesterday').
-      Here is the conversation so far:\n${conversation}\n
+    const intentPrompt = `
+      You are a financial assistant chatbot. Your task is to understand the user's request about their transactions.
+      The current date is ${currentDate}. Use this as a reference for relative date queries (e.g., 'last week', 'yesterday').
+
+      Conversation so far:\n${conversation}\n
+
       Analyze the user's latest message: "${lastUserMessage}"
 
-      Based on the conversation, determine the user's intent and extract relevant parameters. The primary intents are 'list_transactions' and 'get_transaction_summary'.
+      Determine the user's intent and extract relevant parameters. Respond with a JSON object.
 
-      Extract the following parameters if present:
-      - category (e.g., 'groceries', 'rent')
-      - startDate (in YYYY-MM-DD format)
-      - endDate (in YYYY-MM-DD format)
+      Intents:
+      - "list_transactions" — user wants to see specific transactions
+      - "get_transaction_summary" — user wants totals, averages, or breakdowns
+      - "compare_periods" — user wants to compare spending across time periods
+      - "general_question" — general financial question not about their data
 
-      Your response should be a JSON object with the intent and parameters. For example:
-      { "intent": "list_transactions", "parameters": { "category": "restaurants", "startDate": "2025-07-01", "endDate": "2025-07-04" } }
+      Parameters to extract (if present):
+      - category: the category name (e.g., "groceries", "restaurants")
+      - startDate: in YYYY-MM-DD format
+      - endDate: in YYYY-MM-DD format
+      - transactionType: "INCOME" or "EXPENSE"
+
+      Aggregation types — pick the one that best matches the user's question:
+      - "total" — sum of transactions (e.g., "How much did I spend on X?")
+      - "average" — average transaction value (e.g., "What's my average grocery expense?")
+      - "count" — count of transactions (e.g., "How many transactions this month?")
+      - "breakdown_by_category" — group by category (e.g., "Show spending by category")
+      - "breakdown_by_month" — group by month (e.g., "Monthly spending trend")
+      - "min_max" — highest and lowest (e.g., "What was my biggest expense?")
+      - "list" — show individual transactions (e.g., "List my restaurant transactions")
+
+      Examples:
+      - "How much did I spend last month?" → { "intent": "get_transaction_summary", "parameters": { "startDate": "...", "endDate": "...", "transactionType": "EXPENSE" }, "aggregation": "total" }
+      - "What's my average grocery expense?" → { "intent": "get_transaction_summary", "parameters": { "category": "groceries", "transactionType": "EXPENSE" }, "aggregation": "average" }
+      - "Show me spending by category" → { "intent": "get_transaction_summary", "parameters": { "transactionType": "EXPENSE" }, "aggregation": "breakdown_by_category" }
+      - "List my restaurant transactions" → { "intent": "list_transactions", "parameters": { "category": "restaurants" }, "aggregation": "list" }
+
+      Respond ONLY with valid JSON, no markdown fences.
     `;
 
     try {
-      const result = await this.aiProvider.generateContent(prompt);
-      const parsedResult = JSON.parse(result.replace(/```json/g, '').replace(/```/g, ''));
+      const result = await this.aiProvider.generateContent(intentPrompt);
+      const parsedResult: ChatIntent = JSON.parse(
+        result.replace(/```json/g, '').replace(/```/g, '').trim(),
+      );
 
       const { intent, parameters } = parsedResult;
 
-      let transactions: Transaction[] | undefined;
-      if (intent === 'list_transactions' || intent === 'get_transaction_summary') {
-        transactions = await this.transactionRepository.getTransactions({
-          userId,
-          page: 1,
-          perPage: 100,
-          ...parameters,
-        });
-      } else {
+      if (
+        intent !== 'list_transactions' &&
+        intent !== 'get_transaction_summary' &&
+        intent !== 'compare_periods'
+      ) {
         return "I'm sorry, I can only help with questions about your transactions. Please try asking something like, 'How much did I spend on groceries last week?'";
       }
 
-      const finalPrompt = `
-        You are a friendly financial assistant. The current date is ${currentDate}. The user asked: "${lastUserMessage}"
-        You have retrieved the following transaction data: ${JSON.stringify(transactions, null, 2)}
-        
-        Based on this data, provide a clear and concise answer to the user's question.
+      const categoryId = await this.resolveCategoryId(parameters.category);
+
+      const aggregationType = this.resolveAggregationType(parsedResult);
+      const isListQuery = aggregationType === 'list';
+
+      const transactions = await this.transactionRepository.getTransactions({
+        userId,
+        page: 1,
+        perPage: isListQuery ? 100 : 10000,
+        ...(parameters.startDate
+          ? { startDate: new Date(parameters.startDate) }
+          : {}),
+        ...(parameters.endDate
+          ? { endDate: new Date(parameters.endDate) }
+          : {}),
+        ...(parameters.transactionType
+          ? { transactionType: parameters.transactionType }
+          : {}),
+        ...(categoryId ? { categoryId } : {}),
+      });
+
+      const aggregationResult = chatAggregationService.aggregate(
+        transactions,
+        aggregationType,
+      );
+
+      const responsePrompt = `
+        You are a friendly financial assistant. The user asked: "${lastUserMessage}"
+
+        Here are the EXACT pre-computed results. Do NOT recalculate these numbers — use them as-is:
+        ${aggregationResult.summary}
+
+        ${aggregationResult.transactionCount} transactions were analyzed.
+
+        Present this information conversationally to the user. Use the exact numbers provided. Keep currency in ₪ (Israeli Shekel).
       `;
 
-      const finalResult = await this.aiProvider.generateContent(finalPrompt);
-      return finalResult;
+      return await this.aiProvider.generateContent(responsePrompt);
     } catch (error) {
       console.error('Error in ChatService:', error);
       return "I'm sorry, something went wrong while I was trying to understand that. Please try again.";
     }
+  }
+
+  private async resolveCategoryId(
+    categoryName?: string,
+  ): Promise<string | undefined> {
+    if (!categoryName) return undefined;
+
+    const categories = await this.categoryRepository.getAllCategories();
+    const lowerName = categoryName.toLowerCase();
+
+    const exact = categories.find((c) => c.name.toLowerCase() === lowerName);
+    if (exact) return exact.id;
+
+    const partial = categories.find((c) =>
+      c.name.toLowerCase().includes(lowerName),
+    );
+    return partial?.id;
+  }
+
+  private resolveAggregationType(parsed: ChatIntent): AggregationType {
+    if (parsed.aggregation) return parsed.aggregation;
+
+    if (parsed.intent === 'list_transactions') return 'list';
+    return 'total';
   }
 }
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,29 @@
+export type AggregationType =
+  | 'total'
+  | 'average'
+  | 'count'
+  | 'breakdown_by_category'
+  | 'breakdown_by_month'
+  | 'min_max'
+  | 'list';
+
+export interface ChatIntent {
+  intent:
+    | 'list_transactions'
+    | 'get_transaction_summary'
+    | 'compare_periods'
+    | 'general_question';
+  parameters: {
+    category?: string;
+    startDate?: string;
+    endDate?: string;
+    transactionType?: 'INCOME' | 'EXPENSE';
+  };
+  aggregation?: AggregationType;
+}
+
+export interface AggregationResult {
+  summary: string;
+  data: Record<string, number | string>;
+  transactionCount: number;
+}


### PR DESCRIPTION
## Summary
- **Server-side aggregation**: Adds a `chatAggregationService` that computes totals, averages, counts, category/monthly breakdowns, min/max, and formatted lists deterministically — the LLM now only formats pre-computed numbers into conversational responses
- **Category filter fix**: Resolves LLM-extracted category names (e.g., "groceries") to `categoryId` UUIDs via case-insensitive lookup against the category repository, fixing the silently broken category filter
- **Build fix**: Replaces `rimraf` with `rm -rf` in the build script to resolve ESM/CJS incompatibility with Node.js v20 in the npm workspace setup

## Test plan
- [ ] Start API dev server (`npm run watch`) and test chat queries
- [ ] "How much did I spend last month?" — returns consistent total every time
- [ ] "What's my average grocery expense?" — returns exact average
- [ ] "Show me spending by category this month" — correct per-category breakdown
- [ ] "List my recent transactions" — still works as before
- [ ] Run same question multiple times — numbers must be identical
- [ ] `npm run ts.check` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)