### PR TITLE
Add approve option for matched imported transactions

### DIFF
--- a/dist/repositories/importedTransactionRepository.js
+++ b/dist/repositories/importedTransactionRepository.js
@@ -48,6 +48,12 @@ class ImportedTransactionRepository {
             where: { id },
         });
     }
+    async clearMatchingTransaction(id, userId) {
+        await client_2.default.importedTransaction.update({
+            where: { id, userId },
+            data: { matchingTransactionId: null },
+        });
+    }
     async updateStatus(id, userId, status) {
         await client_2.default.importedTransaction.update({
             where: { id, userId },

--- a/dist/services/importService.js
+++ b/dist/services/importService.js
@@ -109,6 +109,7 @@ class ImportService {
                 ' and userId: ' +
                 userId);
         }
+        await importedTransactionRepository_1.importedTransactionRepository.clearMatchingTransaction(importedTransactionId, userId);
         await transactionService_1.default.createTransaction({
             description: transactionData.description,
             value: transactionData.value,

--- a/src/repositories/importedTransactionRepository.ts
+++ b/src/repositories/importedTransactionRepository.ts
@@ -66,6 +66,13 @@ export class ImportedTransactionRepository {
     });
   }
 
+  async clearMatchingTransaction(id: string, userId: string): Promise<void> {
+    await prisma.importedTransaction.update({
+      where: { id, userId },
+      data: { matchingTransactionId: null },
+    });
+  }
+
   async updateStatus(
     id: string,
     userId: string,

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -167,6 +167,11 @@ class ImportService {
       );
     }
 
+    await importedTransactionRepository.clearMatchingTransaction(
+      importedTransactionId,
+      userId,
+    );
+
     await transactionService.createTransaction({
       description: transactionData.description,
       value: transactionData.value,


### PR DESCRIPTION
## Summary
When approving an imported transaction that has a matching transaction, the match is now unlinked (matchingTransactionId set to null) before creating the new transaction. This supports the new UI flow where users can reject a false-positive match and create a new transaction instead.

## Changes
- Added `clearMatchingTransaction` method to `ImportedTransactionRepository`
- Called it in `ImportService.approveImportedTransaction` before creating the new transaction

## Test plan
- [ ] Approve an imported transaction that has a matching transaction — verify the match is cleared and a new transaction is created
- [ ] Approve an imported transaction without a matching transaction — verify behavior is unchanged
- [ ] Verify the approved imported transaction status is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)