### PR TITLE
feat: match imports against pending scheduled transactions

### DIFF
--- a/dist/repositories/transactionRepository.js
+++ b/dist/repositories/transactionRepository.js
@@ -149,8 +149,11 @@ class TransactionRepository {
                     gte: value - tolerance,
                     lte: value + tolerance,
                 },
-                status: client_1.TransactionStatus.APPROVED,
+                status: {
+                    in: [client_1.TransactionStatus.APPROVED, client_1.TransactionStatus.PENDING_APPROVAL],
+                },
             },
+            orderBy: { status: 'desc' },
             include: { category: true },
         });
         return potentialTransactions.map(this.mapToDomain);

--- a/dist/services/importService.js
+++ b/dist/services/importService.js
@@ -149,6 +149,9 @@ class ImportService {
             date: transactionData.date,
             categoryId: transactionData.categoryId,
         }, userId);
+        if (matchingTransaction.status === client_1.TransactionStatus.PENDING_APPROVAL) {
+            await transactionService_1.default.updateTransactionStatus(importedTransaction.matchingTransactionId, client_1.TransactionStatus.APPROVED, userId);
+        }
         await importedTransactionRepository_1.importedTransactionRepository.updateStatus(importedTransactionId, userId, client_1.ImportedTransactionStatus.MERGED);
     }
     async ignoreImportedTransaction(importedTransactionId, userId) {

--- a/src/repositories/transactionRepository.ts
+++ b/src/repositories/transactionRepository.ts
@@ -203,8 +203,11 @@ class TransactionRepository {
           gte: value - tolerance,
           lte: value + tolerance,
         },
-        status: TransactionStatus.APPROVED,
+        status: {
+          in: [TransactionStatus.APPROVED, TransactionStatus.PENDING_APPROVAL],
+        },
       },
+      orderBy: { status: 'desc' },
       include: { category: true },
     });
 

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -242,6 +242,14 @@ class ImportService {
       userId,
     );
 
+    if (matchingTransaction.status === TransactionStatus.PENDING_APPROVAL) {
+      await transactionService.updateTransactionStatus(
+        importedTransaction.matchingTransactionId,
+        TransactionStatus.APPROVED,
+        userId,
+      );
+    }
+
     await importedTransactionRepository.updateStatus(
       importedTransactionId,
       userId,


### PR DESCRIPTION
## Summary
- Extend import matching to include `PENDING_APPROVAL` transactions (generated by scheduled transaction processing), with priority over `APPROVED` matches
- Auto-approve `PENDING_APPROVAL` transactions when merged with an imported transaction
- Uses existing `updateTransactionStatus` path so notification flow is preserved

## Changes
- `transactionRepository.findPotentialMatches`: Widened status filter to include both `APPROVED` and `PENDING_APPROVAL`, with `desc` sort to prioritize pending matches
- `importService.mergeImportedTransaction`: Added conditional `updateTransactionStatus` call to approve pending matches on merge

## Test plan
- [ ] Import a file that contains a transaction matching a pending scheduled transaction
- [ ] Verify the pending transaction appears as a match suggestion
- [ ] Verify pending matches are prioritized over approved matches
- [ ] Merge the imported transaction and verify the matched transaction status changes to APPROVED
- [ ] Verify batch approve/merge also auto-approves pending matches
- [ ] Verify auto-approve rules also handle pending matches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)