### PR TITLE
feat: add REMATCHING status for import rematch

### DIFF
--- a/dist/controllers/importController.js
+++ b/dist/controllers/importController.js
@@ -305,6 +305,18 @@ class ImportController {
             throw error;
         }
     }
+    async rematchImport(importId, userId) {
+        try {
+            logger_1.default.debug('Start rematch import', { importId, userId });
+            await importService_1.importService.rematchImport(importId, userId);
+            logger_1.default.debug('Done rematch import');
+            return { success: true };
+        }
+        catch (error) {
+            logger_1.default.error('Failed to rematch import', { importId, userId, error });
+            throw error;
+        }
+    }
     async batchAction(req, userId) {
         try {
             logger_1.default.debug('Start batch action', { req, userId });

--- a/dist/routers/importRouter.js
+++ b/dist/routers/importRouter.js
@@ -25,6 +25,7 @@ router.delete('/auto-approve-rules/:ruleId', (0, handleRequest_1.handleRequest)(
     return importController_1.importController.deleteAutoApproveRule(req.params.ruleId, (_a = req.userId) !== null && _a !== void 0 ? _a : '');
 }, 200));
 router.delete('/:importId', (0, handleRequest_1.handleRequest)((req) => { var _a; return importController_1.importController.deleteImport(req.params.importId, (_a = req.userId) !== null && _a !== void 0 ? _a : ''); }, 200));
+router.post('/:importId/rematch', (0, handleRequest_1.handleRequest)((req) => { var _a; return importController_1.importController.rematchImport(req.params.importId, (_a = req.userId) !== null && _a !== void 0 ? _a : ''); }, 200));
 router.post('/:importId/apply-auto-approve-rules', (0, handleRequest_1.handleRequest)((req) => {
     var _a;
     return importController_1.importController.applyAutoApproveRules(req.params.importId, (_a = req.userId) !== null && _a !== void 0 ? _a : '');

--- a/dist/services/importService.js
+++ b/dist/services/importService.js
@@ -275,6 +275,68 @@ class ImportService {
         }
         return result;
     }
+    async rematchImport(importId, userId) {
+        var _a, _b;
+        const importRecord = await importRepository_1.importRepository.findById(importId);
+        if (!importRecord || importRecord.userId !== userId || importRecord.deleted) {
+            throw new Error('Import not found');
+        }
+        if (importRecord.status !== client_1.ImportStatus.COMPLETED) {
+            throw new Error('Import must be in COMPLETED status to re-match');
+        }
+        const allTransactions = await importedTransactionRepository_1.importedTransactionRepository.findByUserIdAndImportId(userId, importId);
+        const pendingTransactions = allTransactions.filter((t) => t.status === client_1.ImportedTransactionStatus.PENDING);
+        if (pendingTransactions.length === 0) {
+            throw new Error('No pending transactions to re-match');
+        }
+        await importRepository_1.importRepository.updateStatus(importId, client_1.ImportStatus.REMATCHING);
+        try {
+            const excludedTransactionIds = new Set(allTransactions
+                .filter((t) => t.status !== client_1.ImportedTransactionStatus.PENDING &&
+                t.matchingTransactionId)
+                .map((t) => t.matchingTransactionId));
+            await client_2.default.importedTransaction.updateMany({
+                where: {
+                    importId,
+                    userId,
+                    status: client_1.ImportedTransactionStatus.PENDING,
+                },
+                data: { matchingTransactionId: null },
+            });
+            for (const transaction of pendingTransactions) {
+                try {
+                    const matches = await transactionRepository_1.default.findPotentialMatches(userId, transaction.date, transaction.value);
+                    const availableMatches = matches.filter((m) => !excludedTransactionIds.has(m.id));
+                    if (availableMatches.length === 0)
+                        continue;
+                    const bestMatchId = await this.aiProvider.findMatchingTransaction(transaction.description, availableMatches);
+                    const matchingTransactionId = (_b = bestMatchId !== null && bestMatchId !== void 0 ? bestMatchId : (_a = availableMatches[0]) === null || _a === void 0 ? void 0 : _a.id) !== null && _b !== void 0 ? _b : null;
+                    if (matchingTransactionId) {
+                        await client_2.default.importedTransaction.update({
+                            where: { id: transaction.id },
+                            data: { matchingTransactionId },
+                        });
+                        excludedTransactionIds.add(matchingTransactionId);
+                    }
+                }
+                catch (error) {
+                    logger_1.default.error('Error re-matching transaction', {
+                        transactionId: transaction.id,
+                        error,
+                    });
+                }
+            }
+            await importRepository_1.importRepository.updateStatus(importId, client_1.ImportStatus.COMPLETED);
+            logger_1.default.info('Completed re-matching import', {
+                importId,
+                pendingCount: pendingTransactions.length,
+            });
+        }
+        catch (error) {
+            await importRepository_1.importRepository.updateStatus(importId, client_1.ImportStatus.FAILED, error instanceof Error ? error.message : 'Re-match failed');
+            throw error;
+        }
+    }
     async findPotentialMatchesForImport(importId, userId) {
         try {
             logger_1.default.info('Finding potential matches for import', {

--- a/dist/services/importService.js
+++ b/dist/services/importService.js
@@ -276,7 +276,6 @@ class ImportService {
         return result;
     }
     async rematchImport(importId, userId) {
-        var _a, _b;
         const importRecord = await importRepository_1.importRepository.findById(importId);
         if (!importRecord || importRecord.userId !== userId || importRecord.deleted) {
             throw new Error('Import not found');
@@ -305,18 +304,9 @@ class ImportService {
             });
             for (const transaction of pendingTransactions) {
                 try {
-                    const matches = await transactionRepository_1.default.findPotentialMatches(userId, transaction.date, transaction.value);
-                    const availableMatches = matches.filter((m) => !excludedTransactionIds.has(m.id));
-                    if (availableMatches.length === 0)
-                        continue;
-                    const bestMatchId = await this.aiProvider.findMatchingTransaction(transaction.description, availableMatches);
-                    const matchingTransactionId = (_b = bestMatchId !== null && bestMatchId !== void 0 ? bestMatchId : (_a = availableMatches[0]) === null || _a === void 0 ? void 0 : _a.id) !== null && _b !== void 0 ? _b : null;
-                    if (matchingTransactionId) {
-                        await client_2.default.importedTransaction.update({
-                            where: { id: transaction.id },
-                            data: { matchingTransactionId },
-                        });
-                        excludedTransactionIds.add(matchingTransactionId);
+                    const matchedId = await this.matchSingleTransaction(transaction, userId, excludedTransactionIds);
+                    if (matchedId) {
+                        excludedTransactionIds.add(matchedId);
                     }
                 }
                 catch (error) {
@@ -349,36 +339,14 @@ class ImportService {
                 count: importedTransactions.length,
             });
             await Promise.all(importedTransactions.map(async (transaction) => {
-                var _a, _b;
                 try {
-                    const matches = await transactionRepository_1.default.findPotentialMatches(userId, transaction.date, transaction.value);
-                    let matchingTransactionId = null;
-                    if (matches.length > 0) {
-                        logger_1.default.debug('Found potential matches for transaction', {
-                            transactionId: transaction.id,
-                            matchCount: matches.length,
-                        });
-                        const bestMatchId = await this.aiProvider.findMatchingTransaction(transaction.description, matches);
-                        matchingTransactionId = (_b = bestMatchId !== null && bestMatchId !== void 0 ? bestMatchId : (_a = matches[0]) === null || _a === void 0 ? void 0 : _a.id) !== null && _b !== void 0 ? _b : null;
-                        logger_1.default.debug('Selected matching transaction', {
-                            transactionId: transaction.id,
-                            matchingTransactionId,
-                            usedAI: !!bestMatchId,
-                        });
-                    }
-                    if (matchingTransactionId) {
-                        await client_2.default.importedTransaction.update({
-                            where: { id: transaction.id },
-                            data: { matchingTransactionId },
-                        });
-                    }
+                    await this.matchSingleTransaction(transaction, userId);
                 }
                 catch (error) {
                     logger_1.default.error('Error finding match for transaction', {
                         transactionId: transaction.id,
                         error,
                     });
-                    // Continue processing other transactions even if one fails
                 }
             }));
             logger_1.default.info('Completed finding potential matches', {
@@ -392,6 +360,24 @@ class ImportService {
             });
             throw error;
         }
+    }
+    async matchSingleTransaction(transaction, userId, excludedIds) {
+        var _a, _b;
+        const matches = await transactionRepository_1.default.findPotentialMatches(userId, transaction.date, transaction.value);
+        const availableMatches = excludedIds
+            ? matches.filter((m) => !excludedIds.has(m.id))
+            : matches;
+        if (availableMatches.length === 0)
+            return null;
+        const bestMatchId = await this.aiProvider.findMatchingTransaction(transaction.description, availableMatches);
+        const matchingTransactionId = (_b = bestMatchId !== null && bestMatchId !== void 0 ? bestMatchId : (_a = availableMatches[0]) === null || _a === void 0 ? void 0 : _a.id) !== null && _b !== void 0 ? _b : null;
+        if (matchingTransactionId) {
+            await client_2.default.importedTransaction.update({
+                where: { id: transaction.id },
+                data: { matchingTransactionId },
+            });
+        }
+        return matchingTransactionId;
     }
 }
 exports.importService = new ImportService();

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -306,6 +306,19 @@ class ImportController {
       throw error;
     }
   }
+
+  async rematchImport(importId: string, userId: string) {
+    try {
+      logger.debug('Start rematch import', { importId, userId });
+      await importService.rematchImport(importId, userId);
+      logger.debug('Done rematch import');
+      return { success: true };
+    } catch (error) {
+      logger.error('Failed to rematch import', { importId, userId, error });
+      throw error;
+    }
+  }
+
   async batchAction(req: BatchActionRequest, userId: string) {
     try {
       logger.debug('Start batch action', { req, userId });

--- a/src/prisma/migrations/20260403112017_add_rematching_status/migration.sql
+++ b/src/prisma/migrations/20260403112017_add_rematching_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ImportStatus" ADD VALUE 'REMATCHING';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -35,6 +35,7 @@ enum ImportStatus {
   PROCESSING
   COMPLETED
   FAILED
+  REMATCHING
 }
 
 enum ImportFileType {

--- a/src/routers/importRouter.ts
+++ b/src/routers/importRouter.ts
@@ -93,6 +93,15 @@ router.delete(
 );
 
 router.post(
+  '/:importId/rematch',
+  handleRequest(
+    (req) =>
+      importController.rematchImport(req.params.importId, req.userId ?? ''),
+    200,
+  ),
+);
+
+router.post(
   '/:importId/apply-auto-approve-rules',
   handleRequest(
     (req) =>

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -479,33 +479,14 @@ class ImportService {
 
       for (const transaction of pendingTransactions) {
         try {
-          const matches = await transactionRepository.findPotentialMatches(
+          const matchedId = await this.matchSingleTransaction(
+            transaction,
             userId,
-            transaction.date,
-            transaction.value,
+            excludedTransactionIds,
           );
 
-          const availableMatches = matches.filter(
-            (m) => !excludedTransactionIds.has(m.id),
-          );
-
-          if (availableMatches.length === 0) continue;
-
-          const bestMatchId = await this.aiProvider.findMatchingTransaction(
-            transaction.description,
-            availableMatches,
-          );
-
-          const matchingTransactionId =
-            bestMatchId ?? availableMatches[0]?.id ?? null;
-
-          if (matchingTransactionId) {
-            await prisma.importedTransaction.update({
-              where: { id: transaction.id },
-              data: { matchingTransactionId },
-            });
-
-            excludedTransactionIds.add(matchingTransactionId);
+          if (matchedId) {
+            excludedTransactionIds.add(matchedId);
           }
         } catch (error) {
           logger.error('Error re-matching transaction', {
@@ -552,45 +533,12 @@ class ImportService {
       await Promise.all(
         importedTransactions.map(async (transaction) => {
           try {
-            const matches = await transactionRepository.findPotentialMatches(
-              userId,
-              transaction.date,
-              transaction.value,
-            );
-
-            let matchingTransactionId = null;
-            if (matches.length > 0) {
-              logger.debug('Found potential matches for transaction', {
-                transactionId: transaction.id,
-                matchCount: matches.length,
-              });
-
-              const bestMatchId = await this.aiProvider.findMatchingTransaction(
-                transaction.description,
-                matches,
-              );
-
-              matchingTransactionId = bestMatchId ?? matches[0]?.id ?? null;
-
-              logger.debug('Selected matching transaction', {
-                transactionId: transaction.id,
-                matchingTransactionId,
-                usedAI: !!bestMatchId,
-              });
-            }
-
-            if (matchingTransactionId) {
-              await prisma.importedTransaction.update({
-                where: { id: transaction.id },
-                data: { matchingTransactionId },
-              });
-            }
+            await this.matchSingleTransaction(transaction, userId);
           } catch (error) {
             logger.error('Error finding match for transaction', {
               transactionId: transaction.id,
               error,
             });
-            // Continue processing other transactions even if one fails
           }
         }),
       );
@@ -605,6 +553,41 @@ class ImportService {
       });
       throw error;
     }
+  }
+
+  private async matchSingleTransaction(
+    transaction: { id: string; description: string; date: Date; value: number },
+    userId: string,
+    excludedIds?: Set<string>,
+  ): Promise<string | null> {
+    const matches = await transactionRepository.findPotentialMatches(
+      userId,
+      transaction.date,
+      transaction.value,
+    );
+
+    const availableMatches = excludedIds
+      ? matches.filter((m) => !excludedIds.has(m.id))
+      : matches;
+
+    if (availableMatches.length === 0) return null;
+
+    const bestMatchId = await this.aiProvider.findMatchingTransaction(
+      transaction.description,
+      availableMatches,
+    );
+
+    const matchingTransactionId =
+      bestMatchId ?? availableMatches[0]?.id ?? null;
+
+    if (matchingTransactionId) {
+      await prisma.importedTransaction.update({
+        where: { id: transaction.id },
+        data: { matchingTransactionId },
+      });
+    }
+
+    return matchingTransactionId;
   }
 }
 

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -434,6 +434,103 @@ class ImportService {
     return result;
   }
 
+  public async rematchImport(importId: string, userId: string): Promise<void> {
+    const importRecord = await importRepository.findById(importId);
+    if (!importRecord || importRecord.userId !== userId || importRecord.deleted) {
+      throw new Error('Import not found');
+    }
+
+    if (importRecord.status !== ImportStatus.COMPLETED) {
+      throw new Error('Import must be in COMPLETED status to re-match');
+    }
+
+    const allTransactions =
+      await importedTransactionRepository.findByUserIdAndImportId(userId, importId);
+
+    const pendingTransactions = allTransactions.filter(
+      (t) => t.status === ImportedTransactionStatus.PENDING,
+    );
+
+    if (pendingTransactions.length === 0) {
+      throw new Error('No pending transactions to re-match');
+    }
+
+    await importRepository.updateStatus(importId, ImportStatus.REMATCHING);
+
+    try {
+      const excludedTransactionIds = new Set(
+        allTransactions
+          .filter(
+            (t) =>
+              t.status !== ImportedTransactionStatus.PENDING &&
+              t.matchingTransactionId,
+          )
+          .map((t) => t.matchingTransactionId!),
+      );
+
+      await prisma.importedTransaction.updateMany({
+        where: {
+          importId,
+          userId,
+          status: ImportedTransactionStatus.PENDING,
+        },
+        data: { matchingTransactionId: null },
+      });
+
+      for (const transaction of pendingTransactions) {
+        try {
+          const matches = await transactionRepository.findPotentialMatches(
+            userId,
+            transaction.date,
+            transaction.value,
+          );
+
+          const availableMatches = matches.filter(
+            (m) => !excludedTransactionIds.has(m.id),
+          );
+
+          if (availableMatches.length === 0) continue;
+
+          const bestMatchId = await this.aiProvider.findMatchingTransaction(
+            transaction.description,
+            availableMatches,
+          );
+
+          const matchingTransactionId =
+            bestMatchId ?? availableMatches[0]?.id ?? null;
+
+          if (matchingTransactionId) {
+            await prisma.importedTransaction.update({
+              where: { id: transaction.id },
+              data: { matchingTransactionId },
+            });
+
+            excludedTransactionIds.add(matchingTransactionId);
+          }
+        } catch (error) {
+          logger.error('Error re-matching transaction', {
+            transactionId: transaction.id,
+            error,
+          });
+        }
+      }
+
+      await importRepository.updateStatus(importId, ImportStatus.COMPLETED);
+
+      logger.info('Completed re-matching import', {
+        importId,
+        pendingCount: pendingTransactions.length,
+      });
+    } catch (error) {
+      await importRepository.updateStatus(
+        importId,
+        ImportStatus.FAILED,
+        error instanceof Error ? error.message : 'Re-match failed',
+      );
+      throw error;
+    }
+  }
+
   public async findPotentialMatchesForImport(
     importId: string,
     userId: string,


### PR DESCRIPTION
## Summary
- Add `REMATCHING` value to `ImportStatus` Prisma enum with migration
- Add `POST /api/imports/:importId/rematch` endpoint (controller + route)
- Implement `rematchImport` service method with status sandwich (REMATCHING → COMPLETED/FAILED)
- Extract shared `matchSingleTransaction` helper to eliminate duplication with `findPotentialMatchesForImport`

## Test plan
- [ ] Verify migration applies cleanly: `npx prisma migrate deploy`
- [ ] Test rematch on a COMPLETED import with PENDING transactions
- [ ] Verify status transitions: COMPLETED → REMATCHING → COMPLETED (success) / FAILED (error)
- [ ] Verify rematch is rejected on non-COMPLETED imports
- [ ] Verify 1:1 matching constraint (no duplicate matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)