### PR TITLE
fix: pin Vercel to Node 22, which the deploy runtime requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "ts.check": "tsc --project tsconfig.json",
     "postinstall": "prisma generate"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "keywords": [],
   "pre-commit": [
     "ts.check",
@@ -46,7 +49,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^3.3.3",
     "prisma": "^6.9.0",
-"ts-node": "^10.9.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.7.0"
   },


### PR DESCRIPTION
## What

Adds `engines.node: "22.x"` to `package.json`.

## Why

Vercel currently builds this API on **Node 20.20.2**, and the build log already warns:

```
Error: Node.js version 20.x is deprecated. Deployments created on or after
2026-10-01 will fail to build.
```

That is about to become an outright blocker rather than a warning. The dependencies being added for the Mastra assistant (#21) declare `node >=22`:

```
npm warn EBADENGINE package: '@ai-sdk/provider-utils@5.0.13'
npm warn EBADENGINE   required: { node: '>=22' }
npm warn EBADENGINE   current: { node: 'v20.20.2' }
```

Node 20 cannot `require()` an ES module, so this does not fail at build time — it **builds green and then crashes on every request**:

```
FUNCTION_INVOCATION_FAILED

Error [ERR_REQUIRE_ESM]: require() of ES Module .../p-map/index.js
from .../@mastra/core/dist/workspace-SsEU6Si6.cjs not supported.
Node.js process exited with exit status: 1
```

Node 22.12+ permits `require()` of an ES module; Node 20 does not. That is the whole difference.

## Why `engines.node` and not Project Settings

`vercel.json` uses the legacy `builds` array, which makes the dashboard settings inert:

> **WARNING!** Due to `builds` existing in your configuration file, the Build and Development Settings defined in your Project Settings will not apply.

So changing the Node version in the Vercel UI would have no effect. `engines.node` is the lever that works. Because it lives in the repo, both Vercel projects that deploy from it — **my-expenses** and **my-expenses-api** — pick it up from one change.

## Why 22.x and not 24.x

Vercel's message recommends 24.x, and that move should happen before the October deadline. It is deliberately not bundled here:

- 22 is what this was verified against locally (`ts.check` and `build` pass, full assistant e2e suite passes on Node 22.22).
- 22 is what the new dependencies actually ask for.
- 24 is untested from my side, and a runtime jump deserves its own change and its own verification rather than riding along with a crash fix.

**Follow-up worth tracking:** bump to 24.x before 2026-10-01, verified separately.

## Merge order

This should merge **before** #21. On its own it is a no-op for current behaviour — `main` has no ESM-only dependencies, so Node 20 works today. Merging #21 first would deploy an API that builds green and 500s on every request.

## Testing

- `npm run ts.check` and `npm run build` pass
- Local Node (22.22.2) satisfies the new constraint, so existing workflows are unaffected

Also normalises one stray unindented line in `devDependencies`, from reserialising the file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfGStxChbSmEKprg6bRXpn)_