### PR TITLE
fix: load Mastra through a dynamic import so the API boots on Vercel

### DIFF
--- a/dist/services/assistant/esm.js
+++ b/dist/services/assistant/esm.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.importEsm = importEsm;
+/**
+ * Loads an ES module from CommonJS without tsc turning it back into a require.
+ *
+ * Mastra is published as dual ESM/CJS. Its CommonJS build `require`s packages
+ * that are ESM-only (`tokenx` ships no CJS build at all), which only works on a
+ * runtime that supports `require(esm)`. Vercel's Node runtime does not — the
+ * whole process dies at startup with ERR_REQUIRE_ESM, so every route 500s, not
+ * just the assistant. Loading Mastra's ESM build instead sidesteps the issue for
+ * every such dependency at once, present and future.
+ *
+ * A plain `await import(...)` would not survive compilation: this project emits
+ * CommonJS (tsconfig `module: commonjs`), and tsc rewrites dynamic imports into
+ * `require()` calls, which is exactly the thing being avoided. Going through
+ * `new Function` keeps a genuine `import()` in the emitted JavaScript, so Node
+ * resolves the package's "import" condition.
+ */
+const dynamicImport = new Function('specifier', 'return import(specifier)');
+function importEsm(specifier) {
+    return dynamicImport(specifier);
+}

--- a/dist/services/assistant/financialAssistant.js
+++ b/dist/services/assistant/financialAssistant.js
@@ -1,10 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.financialAssistant = void 0;
-const agent_1 = require("@mastra/core/agent");
+exports.getFinancialAssistant = getFinancialAssistant;
 const model_1 = require("./model");
 const memory_1 = require("./memory");
 const tools_1 = require("./tools");
+const esm_1 = require("./esm");
 function buildInstructions() {
     const currentDate = new Date().toISOString().split('T')[0];
     return `
@@ -46,8 +46,31 @@ questions that are not about the user's data, but keep them brief and do not
 give regulated financial, tax, or investment advice.
 `.trim();
 }
-const memory = (0, memory_1.getAssistantMemory)();
-exports.financialAssistant = new agent_1.Agent(Object.assign({ id: 'financial-assistant', name: 'Financial Assistant', 
-    // Passed as a function so the current date is resolved per request rather
-    // than frozen when the module is first loaded.
-    instructions: buildInstructions, model: model_1.getAssistantModel, tools: tools_1.assistantTools }, (memory ? { memory } : {})));
+let assistant;
+/**
+ * The shared agent, constructed on first use and reused afterwards.
+ *
+ * Async because Mastra is reached through a dynamic import (see ./esm), which
+ * also means nothing Mastra-related is loaded until someone actually chats —
+ * routes that never touch the assistant pay nothing for it.
+ */
+function getFinancialAssistant() {
+    // A rejected promise is dropped rather than cached, so one failed build does
+    // not disable chat for the lifetime of the process.
+    assistant !== null && assistant !== void 0 ? assistant : (assistant = build().catch((error) => {
+        assistant = undefined;
+        throw error;
+    }));
+    return assistant;
+}
+async function build() {
+    const [{ Agent }, tools, memory] = await Promise.all([
+        (0, esm_1.importEsm)('@mastra/core/agent'),
+        (0, tools_1.buildAssistantTools)(),
+        (0, memory_1.getAssistantMemory)(),
+    ]);
+    return new Agent(Object.assign({ id: 'financial-assistant', name: 'Financial Assistant', 
+        // Passed as a function so the current date is resolved per request rather
+        // than frozen when the agent is first built.
+        instructions: buildInstructions, model: model_1.getAssistantModel, tools }, (memory ? { memory } : {})));
+}

--- a/dist/services/assistant/memory.js
+++ b/dist/services/assistant/memory.js
@@ -6,9 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getAssistantMemory = getAssistantMemory;
 exports.isMemoryEnabled = isMemoryEnabled;
 exports.getThreadId = getThreadId;
-const memory_1 = require("@mastra/memory");
-const pg_1 = require("@mastra/pg");
 const logger_1 = __importDefault(require("../../utils/logger"));
+const esm_1 = require("./esm");
 /**
  * Mastra manages its own tables, so it needs a direct Postgres connection.
  * DATABASE_URL runs through Prisma Accelerate (see src/prisma/client.ts) and is
@@ -16,30 +15,43 @@ const logger_1 = __importDefault(require("../../utils/logger"));
  */
 const connectionString = process.env.MASTRA_DB_URL || process.env.DIRECT_URL || '';
 const MASTRA_SCHEMA = 'mastra';
+if (!connectionString) {
+    logger_1.default.warn('Assistant memory disabled: set MASTRA_DB_URL or DIRECT_URL to persist conversation threads');
+}
+let memory;
 /**
  * The shared Memory instance, or undefined when no direct connection is
  * configured. The assistant stays usable without memory rather than failing to
  * start, so a missing DIRECT_URL degrades to stateless chat.
  *
- * Built once at module load — the Postgres pool underneath is lazy, so this
- * does not open a connection at startup.
+ * Built at most once and then reused — the Postgres pool underneath is lazy, so
+ * constructing it does not open a connection.
  */
-const memory = connectionString
-    ? new memory_1.Memory({
-        storage: new pg_1.PostgresStore({
+function getAssistantMemory() {
+    if (!connectionString)
+        return Promise.resolve(undefined);
+    // Not cached when it rejects, so a failed build does not permanently
+    // disable memory for the rest of the process's life.
+    memory !== null && memory !== void 0 ? memory : (memory = build(connectionString).catch((error) => {
+        memory = undefined;
+        throw error;
+    }));
+    return memory;
+}
+async function build(url) {
+    const [{ Memory }, { PostgresStore }] = await Promise.all([
+        (0, esm_1.importEsm)('@mastra/memory'),
+        (0, esm_1.importEsm)('@mastra/pg'),
+    ]);
+    return new Memory({
+        storage: new PostgresStore({
             id: 'assistant-memory',
-            connectionString,
+            connectionString: url,
             // Keeps Mastra's self-managed tables out of `public` so they never
             // collide with the Prisma schema or show up as migration drift.
             schemaName: MASTRA_SCHEMA,
         }),
-    })
-    : undefined;
-if (!connectionString) {
-    logger_1.default.warn('Assistant memory disabled: set MASTRA_DB_URL or DIRECT_URL to persist conversation threads');
-}
-function getAssistantMemory() {
-    return memory;
+    });
 }
 /** Whether conversation history is persisted server-side. */
 function isMemoryEnabled() {

--- a/dist/services/assistant/tools.js
+++ b/dist/services/assistant/tools.js
@@ -3,8 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.assistantTools = exports.getSpendingTrends = exports.comparePeriods = exports.summarizeTransactions = exports.listTransactions = exports.listCategories = exports.USER_ID_CONTEXT_KEY = void 0;
-const tools_1 = require("@mastra/core/tools");
+exports.USER_ID_CONTEXT_KEY = void 0;
+exports.buildAssistantTools = buildAssistantTools;
 // Deliberately zod/v4 rather than the bare `zod` import. Zod 3.25 ships both
 // APIs, and the root export is v3 — which routes Mastra through its zod-v3
 // adapter. That adapter's CommonJS build calls `zodToJsonSchema.default(...)`
@@ -17,6 +17,7 @@ const transactionRepository_1 = __importDefault(require("../../repositories/tran
 const categoryRepository_1 = __importDefault(require("../../repositories/categoryRepository"));
 const trendService_1 = __importDefault(require("../trendService"));
 const chatAggregationService_1 = __importDefault(require("../chatAggregationService"));
+const esm_1 = require("./esm");
 exports.USER_ID_CONTEXT_KEY = 'userId';
 /**
  * Caps how many transactions a single tool call aggregates over.
@@ -106,132 +107,139 @@ async function fetchTransactions(userId, filters) {
         ? { transactionType: filters.transactionType }
         : {})), (filters.searchTerm ? { searchTerm: filters.searchTerm } : {})), (categoryId ? { categoryId } : {})));
 }
-exports.listCategories = (0, tools_1.createTool)({
-    id: 'listCategories',
-    description: 'Lists every category available to the user. Call this before filtering by category so you use a real category name rather than guessing one.',
-    inputSchema: v4_1.z.object({}),
-    outputSchema: v4_1.z.object({
-        categories: v4_1.z.array(v4_1.z.string()),
-    }),
-    execute: async (_input, context) => {
-        requireUserId(context);
-        const categories = await categoryRepository_1.default.getAllCategories();
-        return { categories: categories.map((category) => category.name) };
-    },
-});
-exports.listTransactions = (0, tools_1.createTool)({
-    id: 'listTransactions',
-    description: 'Lists individual transactions matching the given filters. Use this when the user wants to see specific transactions rather than a total.',
-    inputSchema: dateFilterSchema,
-    outputSchema: summaryOutputSchema,
-    execute: async (input, context) => summarize(requireUserId(context), input, 'list'),
-});
-exports.summarizeTransactions = (0, tools_1.createTool)({
-    id: 'summarizeTransactions',
-    description: 'Computes a figure over the transactions matching the filters — a total, average, count, category breakdown, monthly breakdown, or highest/lowest. All arithmetic is done server-side; use the returned numbers exactly as given.',
-    inputSchema: dateFilterSchema.extend({
-        aggregation: v4_1.z
-            .enum([
-            'total',
-            'average',
-            'count',
-            'breakdown_by_category',
-            'breakdown_by_month',
-            'min_max',
-        ])
-            .describe('Which figure to compute'),
-    }),
-    outputSchema: summaryOutputSchema,
-    execute: async (input, context) => summarize(requireUserId(context), input, input.aggregation),
-});
-exports.comparePeriods = (0, tools_1.createTool)({
-    id: 'comparePeriods',
-    description: 'Compares two date ranges and returns both totals along with the difference and percentage change, all computed server-side. Always use this for comparisons instead of calling summarizeTransactions twice and subtracting the results yourself.',
-    inputSchema: v4_1.z.object({
-        periodA: periodSchema('January 2026'),
-        periodB: periodSchema('February 2026'),
-        categoryName: v4_1.z
-            .string()
-            .optional()
-            .describe('Restrict both periods to this category'),
-        transactionType: v4_1.z
-            .enum(['INCOME', 'EXPENSE'])
-            .optional()
-            .describe('Restrict both periods to income or expenses'),
-    }),
-    outputSchema: summaryOutputSchema,
-    execute: async (input, context) => {
-        const userId = requireUserId(context);
-        // Resolved once and shared: otherwise each period re-fetches the whole
-        // category list to map the same name.
-        const shared = {
-            categoryId: await resolveCategoryId(input.categoryName),
-            transactionType: input.transactionType,
-        };
-        const [transactionsA, transactionsB] = await Promise.all([
-            fetchTransactions(userId, Object.assign(Object.assign({}, shared), { startDate: input.periodA.startDate, endDate: input.periodA.endDate })),
-            fetchTransactions(userId, Object.assign(Object.assign({}, shared), { startDate: input.periodB.startDate, endDate: input.periodB.endDate })),
-        ]);
-        const result = chatAggregationService_1.default.computeComparison({ label: input.periodA.label, transactions: transactionsA }, { label: input.periodB.label, transactions: transactionsB });
-        return {
-            summary: result.summary,
-            transactionCount: result.transactionCount,
-        };
-    },
-});
-exports.getSpendingTrends = (0, tools_1.createTool)({
-    id: 'getSpendingTrends',
-    description: 'Returns how spending has moved over time, either overall or broken down by category, including the percentage change against the previous period.',
-    inputSchema: v4_1.z.object({
-        period: v4_1.z
-            .enum(['daily', 'weekly', 'monthly', 'yearly'])
-            .describe('Granularity of the trend points'),
-        startDate: v4_1.z.string().optional().describe('Start date, YYYY-MM-DD'),
-        endDate: v4_1.z.string().optional().describe('End date, YYYY-MM-DD'),
-        categoryName: v4_1.z
-            .string()
-            .optional()
-            .describe('Restrict the trend to a single category'),
-        transactionType: v4_1.z.enum(['INCOME', 'EXPENSE']).optional(),
-        byCategory: v4_1.z
-            .boolean()
-            .optional()
-            .describe('Set true to break the trend down per category'),
-    }),
-    outputSchema: v4_1.z.object({
-        summary: v4_1.z.string(),
-    }),
-    execute: async (input, context) => {
-        const userId = requireUserId(context);
-        const categoryId = await resolveCategoryId(input.categoryName);
-        const request = Object.assign(Object.assign(Object.assign(Object.assign({ period: input.period }, (input.startDate ? { startDate: new Date(input.startDate) } : {})), (input.endDate ? { endDate: new Date(input.endDate) } : {})), (categoryId ? { categoryId } : {})), (input.transactionType
-            ? { transactionType: input.transactionType }
-            : {}));
-        if (input.byCategory) {
-            const trends = await trendService_1.default.getCategorySpendingTrends(request, userId);
-            const lines = trends.map((trend) => `  ${trend.categoryName}: ${chatAggregationService_1.default.formatCurrency(trend.totalAmount)} (${chatAggregationService_1.default.formatPercentChange(trend.percentageChange)} vs previous period, trending ${trend.trend})`);
-            return {
-                summary: lines.length
-                    ? `Category trends (${input.period}):\n${lines.join('\n')}`
-                    : 'No trend data found for that period.',
+/**
+ * Builds the tool set. Async because `createTool` comes from Mastra's ESM
+ * build, which can only be reached through a dynamic import (see ./esm).
+ */
+async function buildAssistantTools() {
+    const { createTool } = await (0, esm_1.importEsm)('@mastra/core/tools');
+    const listCategories = createTool({
+        id: 'listCategories',
+        description: 'Lists every category available to the user. Call this before filtering by category so you use a real category name rather than guessing one.',
+        inputSchema: v4_1.z.object({}),
+        outputSchema: v4_1.z.object({
+            categories: v4_1.z.array(v4_1.z.string()),
+        }),
+        execute: async (_input, context) => {
+            requireUserId(context);
+            const categories = await categoryRepository_1.default.getAllCategories();
+            return { categories: categories.map((category) => category.name) };
+        },
+    });
+    const listTransactions = createTool({
+        id: 'listTransactions',
+        description: 'Lists individual transactions matching the given filters. Use this when the user wants to see specific transactions rather than a total.',
+        inputSchema: dateFilterSchema,
+        outputSchema: summaryOutputSchema,
+        execute: async (input, context) => summarize(requireUserId(context), input, 'list'),
+    });
+    const summarizeTransactions = createTool({
+        id: 'summarizeTransactions',
+        description: 'Computes a figure over the transactions matching the filters — a total, average, count, category breakdown, monthly breakdown, or highest/lowest. All arithmetic is done server-side; use the returned numbers exactly as given.',
+        inputSchema: dateFilterSchema.extend({
+            aggregation: v4_1.z
+                .enum([
+                'total',
+                'average',
+                'count',
+                'breakdown_by_category',
+                'breakdown_by_month',
+                'min_max',
+            ])
+                .describe('Which figure to compute'),
+        }),
+        outputSchema: summaryOutputSchema,
+        execute: async (input, context) => summarize(requireUserId(context), input, input.aggregation),
+    });
+    const comparePeriods = createTool({
+        id: 'comparePeriods',
+        description: 'Compares two date ranges and returns both totals along with the difference and percentage change, all computed server-side. Always use this for comparisons instead of calling summarizeTransactions twice and subtracting the results yourself.',
+        inputSchema: v4_1.z.object({
+            periodA: periodSchema('January 2026'),
+            periodB: periodSchema('February 2026'),
+            categoryName: v4_1.z
+                .string()
+                .optional()
+                .describe('Restrict both periods to this category'),
+            transactionType: v4_1.z
+                .enum(['INCOME', 'EXPENSE'])
+                .optional()
+                .describe('Restrict both periods to income or expenses'),
+        }),
+        outputSchema: summaryOutputSchema,
+        execute: async (input, context) => {
+            const userId = requireUserId(context);
+            // Resolved once and shared: otherwise each period re-fetches the whole
+            // category list to map the same name.
+            const shared = {
+                categoryId: await resolveCategoryId(input.categoryName),
+                transactionType: input.transactionType,
             };
-        }
-        const trend = await trendService_1.default.getSpendingTrends(request, userId);
-        const points = trend.points.map((point) => `  ${point.date}: ${chatAggregationService_1.default.formatCurrency(point.amount)} (${point.count} transactions)`);
-        return {
-            summary: [
-                `Spending trend (${trend.period}) from ${trend.startDate} to ${trend.endDate}:`,
-                ...points,
-                `\nTotal: ${chatAggregationService_1.default.formatCurrency(trend.totalAmount)}`,
-                `Change vs previous period: ${chatAggregationService_1.default.formatPercentChange(trend.percentageChange)} (trending ${trend.trend})`,
-            ].join('\n'),
-        };
-    },
-});
-exports.assistantTools = {
-    listCategories: exports.listCategories,
-    listTransactions: exports.listTransactions,
-    summarizeTransactions: exports.summarizeTransactions,
-    comparePeriods: exports.comparePeriods,
-    getSpendingTrends: exports.getSpendingTrends,
-};
+            const [transactionsA, transactionsB] = await Promise.all([
+                fetchTransactions(userId, Object.assign(Object.assign({}, shared), { startDate: input.periodA.startDate, endDate: input.periodA.endDate })),
+                fetchTransactions(userId, Object.assign(Object.assign({}, shared), { startDate: input.periodB.startDate, endDate: input.periodB.endDate })),
+            ]);
+            const result = chatAggregationService_1.default.computeComparison({ label: input.periodA.label, transactions: transactionsA }, { label: input.periodB.label, transactions: transactionsB });
+            return {
+                summary: result.summary,
+                transactionCount: result.transactionCount,
+            };
+        },
+    });
+    const getSpendingTrends = createTool({
+        id: 'getSpendingTrends',
+        description: 'Returns how spending has moved over time, either overall or broken down by category, including the percentage change against the previous period.',
+        inputSchema: v4_1.z.object({
+            period: v4_1.z
+                .enum(['daily', 'weekly', 'monthly', 'yearly'])
+                .describe('Granularity of the trend points'),
+            startDate: v4_1.z.string().optional().describe('Start date, YYYY-MM-DD'),
+            endDate: v4_1.z.string().optional().describe('End date, YYYY-MM-DD'),
+            categoryName: v4_1.z
+                .string()
+                .optional()
+                .describe('Restrict the trend to a single category'),
+            transactionType: v4_1.z.enum(['INCOME', 'EXPENSE']).optional(),
+            byCategory: v4_1.z
+                .boolean()
+                .optional()
+                .describe('Set true to break the trend down per category'),
+        }),
+        outputSchema: v4_1.z.object({
+            summary: v4_1.z.string(),
+        }),
+        execute: async (input, context) => {
+            const userId = requireUserId(context);
+            const categoryId = await resolveCategoryId(input.categoryName);
+            const request = Object.assign(Object.assign(Object.assign(Object.assign({ period: input.period }, (input.startDate ? { startDate: new Date(input.startDate) } : {})), (input.endDate ? { endDate: new Date(input.endDate) } : {})), (categoryId ? { categoryId } : {})), (input.transactionType
+                ? { transactionType: input.transactionType }
+                : {}));
+            if (input.byCategory) {
+                const trends = await trendService_1.default.getCategorySpendingTrends(request, userId);
+                const lines = trends.map((trend) => `  ${trend.categoryName}: ${chatAggregationService_1.default.formatCurrency(trend.totalAmount)} (${chatAggregationService_1.default.formatPercentChange(trend.percentageChange)} vs previous period, trending ${trend.trend})`);
+                return {
+                    summary: lines.length
+                        ? `Category trends (${input.period}):\n${lines.join('\n')}`
+                        : 'No trend data found for that period.',
+                };
+            }
+            const trend = await trendService_1.default.getSpendingTrends(request, userId);
+            const points = trend.points.map((point) => `  ${point.date}: ${chatAggregationService_1.default.formatCurrency(point.amount)} (${point.count} transactions)`);
+            return {
+                summary: [
+                    `Spending trend (${trend.period}) from ${trend.startDate} to ${trend.endDate}:`,
+                    ...points,
+                    `\nTotal: ${chatAggregationService_1.default.formatCurrency(trend.totalAmount)}`,
+                    `Change vs previous period: ${chatAggregationService_1.default.formatPercentChange(trend.percentageChange)} (trending ${trend.trend})`,
+                ].join('\n'),
+            };
+        },
+    });
+    return {
+        listCategories,
+        listTransactions,
+        summarizeTransactions,
+        comparePeriods,
+        getSpendingTrends,
+    };
+}

--- a/dist/services/chatService.js
+++ b/dist/services/chatService.js
@@ -1,9 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const request_context_1 = require("@mastra/core/request-context");
 const financialAssistant_1 = require("./assistant/financialAssistant");
 const memory_1 = require("./assistant/memory");
 const tools_1 = require("./assistant/tools");
+const esm_1 = require("./assistant/esm");
 class ChatService {
     /**
      * Runs the assistant and returns a stream of text deltas.
@@ -13,10 +13,14 @@ class ChatService {
      * turn. Figures always come from tool results, never from the model.
      */
     async streamChatResponse(messages, userId, abortSignal) {
+        const [{ RequestContext }, assistant] = await Promise.all([
+            (0, esm_1.importEsm)('@mastra/core/request-context'),
+            (0, financialAssistant_1.getFinancialAssistant)(),
+        ]);
         // Injected server-side so the model cannot choose whose data it reads.
-        const requestContext = new request_context_1.RequestContext();
+        const requestContext = new RequestContext();
         requestContext.set(tools_1.USER_ID_CONTEXT_KEY, userId);
-        const result = await financialAssistant_1.financialAssistant.stream(this.toModelMessages(messages), Object.assign({ memory: {
+        const result = await assistant.stream(this.toModelMessages(messages), Object.assign({ memory: {
                 thread: (0, memory_1.getThreadId)(userId),
                 resource: userId,
             }, requestContext }, (abortSignal ? { abortSignal } : {})));

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.7.0"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@47ng/cloak": {

--- a/src/services/assistant/esm.ts
+++ b/src/services/assistant/esm.ts
@@ -1,0 +1,23 @@
+/**
+ * Loads an ES module from CommonJS without tsc turning it back into a require.
+ *
+ * Mastra is published as dual ESM/CJS. Its CommonJS build `require`s packages
+ * that are ESM-only (`tokenx` ships no CJS build at all), which only works on a
+ * runtime that supports `require(esm)`. Vercel's Node runtime does not — the
+ * whole process dies at startup with ERR_REQUIRE_ESM, so every route 500s, not
+ * just the assistant. Loading Mastra's ESM build instead sidesteps the issue for
+ * every such dependency at once, present and future.
+ *
+ * A plain `await import(...)` would not survive compilation: this project emits
+ * CommonJS (tsconfig `module: commonjs`), and tsc rewrites dynamic imports into
+ * `require()` calls, which is exactly the thing being avoided. Going through
+ * `new Function` keeps a genuine `import()` in the emitted JavaScript, so Node
+ * resolves the package's "import" condition.
+ */
+const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+  specifier: string,
+) => Promise<unknown>;
+
+export function importEsm<T>(specifier: string): Promise<T> {
+  return dynamicImport(specifier) as Promise<T>;
+}

--- a/src/services/assistant/financialAssistant.ts
+++ b/src/services/assistant/financialAssistant.ts
@@ -1,7 +1,8 @@
-import { Agent } from '@mastra/core/agent';
+import type { Agent } from '@mastra/core/agent';
 import { getAssistantModel } from './model';
 import { getAssistantMemory } from './memory';
-import { assistantTools } from './tools';
+import { buildAssistantTools } from './tools';
+import { importEsm } from './esm';
 
 function buildInstructions(): string {
   const currentDate = new Date().toISOString().split('T')[0];
@@ -46,17 +47,43 @@ give regulated financial, tax, or investment advice.
 `.trim();
 }
 
-const memory = getAssistantMemory();
+let assistant: Promise<Agent> | undefined;
 
-export const financialAssistant = new Agent({
-  id: 'financial-assistant',
-  name: 'Financial Assistant',
-  // Passed as a function so the current date is resolved per request rather
-  // than frozen when the module is first loaded.
-  instructions: buildInstructions,
-  model: getAssistantModel,
-  tools: assistantTools,
-  // Omitted entirely when no direct Postgres connection is configured, so the
-  // assistant still answers (statelessly) instead of failing to construct.
-  ...(memory ? { memory } : {}),
-});
+/**
+ * The shared agent, constructed on first use and reused afterwards.
+ *
+ * Async because Mastra is reached through a dynamic import (see ./esm), which
+ * also means nothing Mastra-related is loaded until someone actually chats —
+ * routes that never touch the assistant pay nothing for it.
+ */
+export function getFinancialAssistant(): Promise<Agent> {
+  // A rejected promise is dropped rather than cached, so one failed build does
+  // not disable chat for the lifetime of the process.
+  assistant ??= build().catch((error) => {
+    assistant = undefined;
+    throw error;
+  });
+
+  return assistant;
+}
+
+async function build(): Promise<Agent> {
+  const [{ Agent }, tools, memory] = await Promise.all([
+    importEsm<typeof import('@mastra/core/agent')>('@mastra/core/agent'),
+    buildAssistantTools(),
+    getAssistantMemory(),
+  ]);
+
+  return new Agent({
+    id: 'financial-assistant',
+    name: 'Financial Assistant',
+    // Passed as a function so the current date is resolved per request rather
+    // than frozen when the agent is first built.
+    instructions: buildInstructions,
+    model: getAssistantModel,
+    tools,
+    // Omitted entirely when no direct Postgres connection is configured, so the
+    // assistant still answers (statelessly) instead of failing to construct.
+    ...(memory ? { memory } : {}),
+  });
+}

--- a/src/services/assistant/memory.ts
+++ b/src/services/assistant/memory.ts
@@ -1,6 +1,6 @@
-import { Memory } from '@mastra/memory';
-import { PostgresStore } from '@mastra/pg';
+import type { Memory } from '@mastra/memory';
 import logger from '../../utils/logger';
+import { importEsm } from './esm';
 
 /**
  * Mastra manages its own tables, so it needs a direct Postgres connection.
@@ -12,34 +12,50 @@ const connectionString =
 
 const MASTRA_SCHEMA = 'mastra';
 
-/**
- * The shared Memory instance, or undefined when no direct connection is
- * configured. The assistant stays usable without memory rather than failing to
- * start, so a missing DIRECT_URL degrades to stateless chat.
- *
- * Built once at module load — the Postgres pool underneath is lazy, so this
- * does not open a connection at startup.
- */
-const memory = connectionString
-  ? new Memory({
-      storage: new PostgresStore({
-        id: 'assistant-memory',
-        connectionString,
-        // Keeps Mastra's self-managed tables out of `public` so they never
-        // collide with the Prisma schema or show up as migration drift.
-        schemaName: MASTRA_SCHEMA,
-      }),
-    })
-  : undefined;
-
 if (!connectionString) {
   logger.warn(
     'Assistant memory disabled: set MASTRA_DB_URL or DIRECT_URL to persist conversation threads',
   );
 }
 
-export function getAssistantMemory(): Memory | undefined {
+let memory: Promise<Memory | undefined> | undefined;
+
+/**
+ * The shared Memory instance, or undefined when no direct connection is
+ * configured. The assistant stays usable without memory rather than failing to
+ * start, so a missing DIRECT_URL degrades to stateless chat.
+ *
+ * Built at most once and then reused — the Postgres pool underneath is lazy, so
+ * constructing it does not open a connection.
+ */
+export function getAssistantMemory(): Promise<Memory | undefined> {
+  if (!connectionString) return Promise.resolve(undefined);
+
+  // Not cached when it rejects, so a failed build does not permanently
+  // disable memory for the rest of the process's life.
+  memory ??= build(connectionString).catch((error) => {
+    memory = undefined;
+    throw error;
+  });
+
   return memory;
+}
+
+async function build(url: string): Promise<Memory> {
+  const [{ Memory }, { PostgresStore }] = await Promise.all([
+    importEsm<typeof import('@mastra/memory')>('@mastra/memory'),
+    importEsm<typeof import('@mastra/pg')>('@mastra/pg'),
+  ]);
+
+  return new Memory({
+    storage: new PostgresStore({
+      id: 'assistant-memory',
+      connectionString: url,
+      // Keeps Mastra's self-managed tables out of `public` so they never
+      // collide with the Prisma schema or show up as migration drift.
+      schemaName: MASTRA_SCHEMA,
+    }),
+  });
 }
 
 /** Whether conversation history is persisted server-side. */

--- a/src/services/assistant/tools.ts
+++ b/src/services/assistant/tools.ts
@@ -1,4 +1,3 @@
-import { createTool } from '@mastra/core/tools';
 // Deliberately zod/v4 rather than the bare `zod` import. Zod 3.25 ships both
 // APIs, and the root export is v3 — which routes Mastra through its zod-v3
 // adapter. That adapter's CommonJS build calls `zodToJsonSchema.default(...)`
@@ -14,6 +13,7 @@ import chatAggregationService from '../chatAggregationService';
 import { Transaction } from '../../types/transaction';
 import { AggregationType } from '../../types/chat';
 import { TrendPeriod } from '../../types/trends';
+import { importEsm } from './esm';
 
 export const USER_ID_CONTEXT_KEY = 'userId';
 
@@ -148,179 +148,188 @@ async function fetchTransactions(
   });
 }
 
-export const listCategories = createTool({
-  id: 'listCategories',
-  description:
-    'Lists every category available to the user. Call this before filtering by category so you use a real category name rather than guessing one.',
-  inputSchema: z.object({}),
-  outputSchema: z.object({
-    categories: z.array(z.string()),
-  }),
-  execute: async (_input, context) => {
-    requireUserId(context);
-    const categories = await categoryRepository.getAllCategories();
-    return { categories: categories.map((category) => category.name) };
-  },
-});
+/**
+ * Builds the tool set. Async because `createTool` comes from Mastra's ESM
+ * build, which can only be reached through a dynamic import (see ./esm).
+ */
+export async function buildAssistantTools() {
+  const { createTool } =
+    await importEsm<typeof import('@mastra/core/tools')>('@mastra/core/tools');
 
-export const listTransactions = createTool({
-  id: 'listTransactions',
-  description:
-    'Lists individual transactions matching the given filters. Use this when the user wants to see specific transactions rather than a total.',
-  inputSchema: dateFilterSchema,
-  outputSchema: summaryOutputSchema,
-  execute: async (input, context) =>
-    summarize(requireUserId(context), input, 'list'),
-});
+  const listCategories = createTool({
+    id: 'listCategories',
+    description:
+      'Lists every category available to the user. Call this before filtering by category so you use a real category name rather than guessing one.',
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      categories: z.array(z.string()),
+    }),
+    execute: async (_input, context) => {
+      requireUserId(context);
+      const categories = await categoryRepository.getAllCategories();
+      return { categories: categories.map((category) => category.name) };
+    },
+  });
 
-export const summarizeTransactions = createTool({
-  id: 'summarizeTransactions',
-  description:
-    'Computes a figure over the transactions matching the filters — a total, average, count, category breakdown, monthly breakdown, or highest/lowest. All arithmetic is done server-side; use the returned numbers exactly as given.',
-  inputSchema: dateFilterSchema.extend({
-    aggregation: z
-      .enum([
-        'total',
-        'average',
-        'count',
-        'breakdown_by_category',
-        'breakdown_by_month',
-        'min_max',
-      ])
-      .describe('Which figure to compute'),
-  }),
-  outputSchema: summaryOutputSchema,
-  execute: async (input, context) =>
-    summarize(requireUserId(context), input, input.aggregation),
-});
+  const listTransactions = createTool({
+    id: 'listTransactions',
+    description:
+      'Lists individual transactions matching the given filters. Use this when the user wants to see specific transactions rather than a total.',
+    inputSchema: dateFilterSchema,
+    outputSchema: summaryOutputSchema,
+    execute: async (input, context) =>
+      summarize(requireUserId(context), input, 'list'),
+  });
 
-export const comparePeriods = createTool({
-  id: 'comparePeriods',
-  description:
-    'Compares two date ranges and returns both totals along with the difference and percentage change, all computed server-side. Always use this for comparisons instead of calling summarizeTransactions twice and subtracting the results yourself.',
-  inputSchema: z.object({
-    periodA: periodSchema('January 2026'),
-    periodB: periodSchema('February 2026'),
-    categoryName: z
-      .string()
-      .optional()
-      .describe('Restrict both periods to this category'),
-    transactionType: z
-      .enum(['INCOME', 'EXPENSE'])
-      .optional()
-      .describe('Restrict both periods to income or expenses'),
-  }),
-  outputSchema: summaryOutputSchema,
-  execute: async (input, context) => {
-    const userId = requireUserId(context);
+  const summarizeTransactions = createTool({
+    id: 'summarizeTransactions',
+    description:
+      'Computes a figure over the transactions matching the filters — a total, average, count, category breakdown, monthly breakdown, or highest/lowest. All arithmetic is done server-side; use the returned numbers exactly as given.',
+    inputSchema: dateFilterSchema.extend({
+      aggregation: z
+        .enum([
+          'total',
+          'average',
+          'count',
+          'breakdown_by_category',
+          'breakdown_by_month',
+          'min_max',
+        ])
+        .describe('Which figure to compute'),
+    }),
+    outputSchema: summaryOutputSchema,
+    execute: async (input, context) =>
+      summarize(requireUserId(context), input, input.aggregation),
+  });
 
-    // Resolved once and shared: otherwise each period re-fetches the whole
-    // category list to map the same name.
-    const shared: DateFilterInput = {
-      categoryId: await resolveCategoryId(input.categoryName),
-      transactionType: input.transactionType,
-    };
+  const comparePeriods = createTool({
+    id: 'comparePeriods',
+    description:
+      'Compares two date ranges and returns both totals along with the difference and percentage change, all computed server-side. Always use this for comparisons instead of calling summarizeTransactions twice and subtracting the results yourself.',
+    inputSchema: z.object({
+      periodA: periodSchema('January 2026'),
+      periodB: periodSchema('February 2026'),
+      categoryName: z
+        .string()
+        .optional()
+        .describe('Restrict both periods to this category'),
+      transactionType: z
+        .enum(['INCOME', 'EXPENSE'])
+        .optional()
+        .describe('Restrict both periods to income or expenses'),
+    }),
+    outputSchema: summaryOutputSchema,
+    execute: async (input, context) => {
+      const userId = requireUserId(context);
 
-    const [transactionsA, transactionsB] = await Promise.all([
-      fetchTransactions(userId, {
-        ...shared,
-        startDate: input.periodA.startDate,
-        endDate: input.periodA.endDate,
-      }),
-      fetchTransactions(userId, {
-        ...shared,
-        startDate: input.periodB.startDate,
-        endDate: input.periodB.endDate,
-      }),
-    ]);
+      // Resolved once and shared: otherwise each period re-fetches the whole
+      // category list to map the same name.
+      const shared: DateFilterInput = {
+        categoryId: await resolveCategoryId(input.categoryName),
+        transactionType: input.transactionType,
+      };
 
-    const result = chatAggregationService.computeComparison(
-      { label: input.periodA.label, transactions: transactionsA },
-      { label: input.periodB.label, transactions: transactionsB },
-    );
+      const [transactionsA, transactionsB] = await Promise.all([
+        fetchTransactions(userId, {
+          ...shared,
+          startDate: input.periodA.startDate,
+          endDate: input.periodA.endDate,
+        }),
+        fetchTransactions(userId, {
+          ...shared,
+          startDate: input.periodB.startDate,
+          endDate: input.periodB.endDate,
+        }),
+      ]);
 
-    return {
-      summary: result.summary,
-      transactionCount: result.transactionCount,
-    };
-  },
-});
-
-export const getSpendingTrends = createTool({
-  id: 'getSpendingTrends',
-  description:
-    'Returns how spending has moved over time, either overall or broken down by category, including the percentage change against the previous period.',
-  inputSchema: z.object({
-    period: z
-      .enum(['daily', 'weekly', 'monthly', 'yearly'])
-      .describe('Granularity of the trend points'),
-    startDate: z.string().optional().describe('Start date, YYYY-MM-DD'),
-    endDate: z.string().optional().describe('End date, YYYY-MM-DD'),
-    categoryName: z
-      .string()
-      .optional()
-      .describe('Restrict the trend to a single category'),
-    transactionType: z.enum(['INCOME', 'EXPENSE']).optional(),
-    byCategory: z
-      .boolean()
-      .optional()
-      .describe('Set true to break the trend down per category'),
-  }),
-  outputSchema: z.object({
-    summary: z.string(),
-  }),
-  execute: async (input, context) => {
-    const userId = requireUserId(context);
-    const categoryId = await resolveCategoryId(input.categoryName);
-
-    const request = {
-      period: input.period as TrendPeriod,
-      ...(input.startDate ? { startDate: new Date(input.startDate) } : {}),
-      ...(input.endDate ? { endDate: new Date(input.endDate) } : {}),
-      ...(categoryId ? { categoryId } : {}),
-      ...(input.transactionType
-        ? { transactionType: input.transactionType }
-        : {}),
-    };
-
-    if (input.byCategory) {
-      const trends = await trendService.getCategorySpendingTrends(
-        request,
-        userId,
-      );
-      const lines = trends.map(
-        (trend) =>
-          `  ${trend.categoryName}: ${chatAggregationService.formatCurrency(trend.totalAmount)} (${chatAggregationService.formatPercentChange(trend.percentageChange)} vs previous period, trending ${trend.trend})`,
+      const result = chatAggregationService.computeComparison(
+        { label: input.periodA.label, transactions: transactionsA },
+        { label: input.periodB.label, transactions: transactionsB },
       );
 
       return {
-        summary: lines.length
-          ? `Category trends (${input.period}):\n${lines.join('\n')}`
-          : 'No trend data found for that period.',
+        summary: result.summary,
+        transactionCount: result.transactionCount,
       };
-    }
+    },
+  });
 
-    const trend = await trendService.getSpendingTrends(request, userId);
-    const points = trend.points.map(
-      (point) =>
-        `  ${point.date}: ${chatAggregationService.formatCurrency(point.amount)} (${point.count} transactions)`,
-    );
+  const getSpendingTrends = createTool({
+    id: 'getSpendingTrends',
+    description:
+      'Returns how spending has moved over time, either overall or broken down by category, including the percentage change against the previous period.',
+    inputSchema: z.object({
+      period: z
+        .enum(['daily', 'weekly', 'monthly', 'yearly'])
+        .describe('Granularity of the trend points'),
+      startDate: z.string().optional().describe('Start date, YYYY-MM-DD'),
+      endDate: z.string().optional().describe('End date, YYYY-MM-DD'),
+      categoryName: z
+        .string()
+        .optional()
+        .describe('Restrict the trend to a single category'),
+      transactionType: z.enum(['INCOME', 'EXPENSE']).optional(),
+      byCategory: z
+        .boolean()
+        .optional()
+        .describe('Set true to break the trend down per category'),
+    }),
+    outputSchema: z.object({
+      summary: z.string(),
+    }),
+    execute: async (input, context) => {
+      const userId = requireUserId(context);
+      const categoryId = await resolveCategoryId(input.categoryName);
 
-    return {
-      summary: [
-        `Spending trend (${trend.period}) from ${trend.startDate} to ${trend.endDate}:`,
-        ...points,
-        `\nTotal: ${chatAggregationService.formatCurrency(trend.totalAmount)}`,
-        `Change vs previous period: ${chatAggregationService.formatPercentChange(trend.percentageChange)} (trending ${trend.trend})`,
-      ].join('\n'),
-    };
-  },
-});
+      const request = {
+        period: input.period as TrendPeriod,
+        ...(input.startDate ? { startDate: new Date(input.startDate) } : {}),
+        ...(input.endDate ? { endDate: new Date(input.endDate) } : {}),
+        ...(categoryId ? { categoryId } : {}),
+        ...(input.transactionType
+          ? { transactionType: input.transactionType }
+          : {}),
+      };
 
-export const assistantTools = {
-  listCategories,
-  listTransactions,
-  summarizeTransactions,
-  comparePeriods,
-  getSpendingTrends,
-};
+      if (input.byCategory) {
+        const trends = await trendService.getCategorySpendingTrends(
+          request,
+          userId,
+        );
+        const lines = trends.map(
+          (trend) =>
+            `  ${trend.categoryName}: ${chatAggregationService.formatCurrency(trend.totalAmount)} (${chatAggregationService.formatPercentChange(trend.percentageChange)} vs previous period, trending ${trend.trend})`,
+        );
+
+        return {
+          summary: lines.length
+            ? `Category trends (${input.period}):\n${lines.join('\n')}`
+            : 'No trend data found for that period.',
+        };
+      }
+
+      const trend = await trendService.getSpendingTrends(request, userId);
+      const points = trend.points.map(
+        (point) =>
+          `  ${point.date}: ${chatAggregationService.formatCurrency(point.amount)} (${point.count} transactions)`,
+      );
+
+      return {
+        summary: [
+          `Spending trend (${trend.period}) from ${trend.startDate} to ${trend.endDate}:`,
+          ...points,
+          `\nTotal: ${chatAggregationService.formatCurrency(trend.totalAmount)}`,
+          `Change vs previous period: ${chatAggregationService.formatPercentChange(trend.percentageChange)} (trending ${trend.trend})`,
+        ].join('\n'),
+      };
+    },
+  });
+
+  return {
+    listCategories,
+    listTransactions,
+    summarizeTransactions,
+    comparePeriods,
+    getSpendingTrends,
+  };
+}

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,7 +1,7 @@
-import { RequestContext } from '@mastra/core/request-context';
-import { financialAssistant } from './assistant/financialAssistant';
+import { getFinancialAssistant } from './assistant/financialAssistant';
 import { getThreadId, isMemoryEnabled } from './assistant/memory';
 import { USER_ID_CONTEXT_KEY } from './assistant/tools';
+import { importEsm } from './assistant/esm';
 
 export interface ChatMessage {
   sender: string;
@@ -29,21 +29,25 @@ class ChatService {
     userId: string,
     abortSignal?: AbortSignal,
   ): Promise<AsyncIterable<string>> {
+    const [{ RequestContext }, assistant] = await Promise.all([
+      importEsm<typeof import('@mastra/core/request-context')>(
+        '@mastra/core/request-context',
+      ),
+      getFinancialAssistant(),
+    ]);
+
     // Injected server-side so the model cannot choose whose data it reads.
     const requestContext = new RequestContext();
     requestContext.set(USER_ID_CONTEXT_KEY, userId);
 
-    const result = await financialAssistant.stream(
-      this.toModelMessages(messages),
-      {
-        memory: {
-          thread: getThreadId(userId),
-          resource: userId,
-        },
-        requestContext,
-        ...(abortSignal ? { abortSignal } : {}),
+    const result = await assistant.stream(this.toModelMessages(messages), {
+      memory: {
+        thread: getThreadId(userId),
+        resource: userId,
       },
-    );
+      requestContext,
+      ...(abortSignal ? { abortSignal } : {}),
+    });
 
     return result.textStream;
   }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -31,6 +31,26 @@ ASSISTANT_MODEL_URL=http://127.0.0.1:51231/v1 npx ts-node src/index.ts
 npx ts-node test/e2e/run.ts
 ```
 
+## Running the way production does
+
+Vercel's Node runtime does not support `require(esm)`. Mastra's CommonJS build
+`require`s ESM-only packages, so importing it statically takes down the whole
+process at startup with `ERR_REQUIRE_ESM` — every route 500s, not just the
+assistant. `src/services/assistant/esm.ts` avoids this by loading Mastra's ESM
+build through a dynamic import.
+
+Step 3 above runs from source, which does not exercise that. To reproduce the
+production loader, build first and start the compiled server with the flag that
+turns `require(esm)` off:
+
+```bash
+npm run build
+node --no-experimental-require-module dist/index.js
+```
+
+If the server boots, the import path is safe. `run.ts` also greps `dist` for
+static `require('@mastra/…')` as a cheap standing guard.
+
 `prisma dev` rather than the `docker-compose.yaml` Postgres: `src/prisma/client.ts`
 imports `PrismaClient` from `@prisma/client/edge`, which speaks the Accelerate
 protocol and cannot open a plain `postgresql://` URL. `prisma dev` provides both

--- a/test/e2e/run.ts
+++ b/test/e2e/run.ts
@@ -1,4 +1,6 @@
 import http from 'http';
+import fs from 'fs';
+import path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { Client } from 'pg';
@@ -135,6 +137,48 @@ function textOf(frames: Frame[]): string {
     .filter((f) => f.type === 'delta')
     .map((f) => f.value || '')
     .join('');
+}
+
+/**
+ * Mastra's CommonJS build `require`s ESM-only packages, so a static
+ * `require('@mastra/…')` anywhere in the compiled output kills the process at
+ * startup on any runtime without `require(esm)` — which is what Vercel's is.
+ * Every route 500s, not just the assistant. Mastra must be reached through the
+ * dynamic import in src/services/assistant/esm.ts instead.
+ *
+ * Reads the committed dist rather than the running server, so run `npm run
+ * build` first for this to mean anything. To check the real thing end to end,
+ * start the compiled server the way production loads it:
+ *
+ *   node --no-experimental-require-module dist/index.js
+ */
+function checkCompiledOutputAvoidsRequireEsm(): void {
+  const distDir = path.join(__dirname, '..', '..', 'dist');
+
+  if (!fs.existsSync(distDir)) {
+    check('compiled output avoids require() of Mastra', false, 'dist missing');
+    return;
+  }
+
+  const offenders: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.js')) {
+        if (/require\(["']@mastra\//.test(fs.readFileSync(full, 'utf8'))) {
+          offenders.push(path.relative(distDir, full));
+        }
+      }
+    }
+  };
+  walk(distDir);
+
+  check(
+    'compiled output avoids require() of Mastra',
+    offenders.length === 0,
+    offenders.length ? offenders.join(', ') : 'no static requires',
+  );
 }
 
 async function main(): Promise<void> {
@@ -329,6 +373,8 @@ async function main(): Promise<void> {
     afterAbort?.status === 401,
     afterAbort ? `status ${afterAbort.status}` : 'API unreachable — it crashed',
   );
+
+  checkCompiledOutputAvoidsRequireEsm();
 
   const failed = results.filter((r) => !r.ok);
   console.log(


### PR DESCRIPTION
## The outage

Merging #21 took the whole API down. Production returns `500 FUNCTION_INVOCATION_FAILED` on **every** route, not just `/api/chat`:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /var/task/node_modules/p-map/index.js
  from /var/task/node_modules/@mastra/core/dist/workspace-SsEU6Si6.cjs not supported.
Node.js process exited with exit status: 1
```

Vercel's Node runtime does not support `require(esm)`. `@mastra/core`'s CommonJS build `require`s ESM-only packages, so `require('@mastra/core/agent')` threw while the module graph was still loading — the process exited before the server ever started listening.

The Node 22 pin from #23 did apply (the build log confirms `Node.js Version "22.x" will be used instead`). It was not the problem: Vercel's loader is stricter than plain Node 22, which does support `require(esm)`. That difference is why this passed local testing.

## Why not just pin the dependency

`p-map` has a last-CommonJS release (v4), so an `overrides` entry fixes that one import. Doing so just surfaces the next: `tokenx`, which ships **no CommonJS build at all**. There is no version to pin to, and any future Mastra dependency can reintroduce the same failure.

## The fix

Mastra is published dual ESM/CJS. Loading its **ESM** build sidesteps every ESM-only dependency at once, present and future.

- New `src/services/assistant/esm.ts` — a dynamic import routed through `new Function`. A plain `await import(...)` would not survive compilation: this project emits CommonJS, and `tsc` rewrites dynamic imports back into `require()`, which is exactly what must be avoided.
- Agent, tools, and memory are now built lazily on first chat and memoized, so nothing Mastra-related loads at startup. Routes that never touch the assistant pay nothing for it.
- A rejected build is not cached, so one transient failure does not disable chat for the life of the process.

`createTool` calls moved inside `buildAssistantTools()` — the tool bodies are unchanged, and per-tool input typing from `inputSchema` is preserved.

## Verification

Run against the production loader this time, not plain Node.

`node --no-experimental-require-module` reproduces Vercel's behaviour exactly — it produced the identical `ERR_REQUIRE_ESM` on the current `main`.

- Compiled server boots under that flag ✅
- **20/20** end-to-end checks pass against the compiled `dist`, including `comparePeriods` called once, `+₪1,100.00` / `+26.83%` originating in `chatAggregationService` rather than the model, cross-user isolation, incremental SSE delivery, and memory persistence
- New standing guard in `test/e2e/run.ts` greps `dist` for static `require('@mastra/…')`. Confirmed it goes **red** when one is reintroduced and green when removed — a guard that cannot fail proves nothing.
- `npm run ts.check`, `npm run build`, and `npx eslint` all clean

`test/e2e/README.md` documents how to reproduce the production loader locally.

## Still not verified

An authenticated chat against real production data — that needs a live user token. Everything below that line (agent loop, tool selection, arithmetic provenance, streaming, memory, auth rejection) is covered by the harness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfGStxChbSmEKprg6bRXpn)_